### PR TITLE
Fix veth pair matching explanation in lesson 00

### DIFF
--- a/lessons/clab/00-docker-networking/exercises/README.md
+++ b/lessons/clab/00-docker-networking/exercises/README.md
@@ -23,13 +23,13 @@ Complete these exercises to reinforce your understanding of the Linux primitives
    ```bash
    ip link show master docker0
    ```
-   Note the veth names and the `@ifN` index numbers.
+   Note the veth names, their interface indexes (the number before the colon), and the `link-netnsid` values.
 
 4. Look inside container `c1` and find the other end of the veth pair:
    ```bash
    docker exec c1 ip addr
    ```
-   Compare the `@ifN` index to what you saw on the host.
+   Inside the container, `eth0` shows `@ifN` -- that N is the interface index of the host-side veth. Find that index in the host output from step 3 to match the pair.
 
 5. Check the container's routing table:
    ```bash
@@ -44,7 +44,7 @@ Complete these exercises to reinforce your understanding of the Linux primitives
 ### Questions
 
 - What is the IP of the `docker0` bridge? How does it relate to the container's default gateway?
-- How can you match a host-side veth to its container-side eth0? (Hint: look at the `@ifN` indexes)
+- How can you match a host-side veth to its container-side eth0? (Hint: start from inside the container)
 - What subnet does Docker use for the default bridge?
 
 ### Cleanup

--- a/lessons/clab/00-docker-networking/script.md
+++ b/lessons/clab/00-docker-networking/script.md
@@ -93,23 +93,19 @@ ip link show master docker0
 
 **Expected Output:**
 ```
-6: vethXXXXXXX@if5: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
-    master docker0 state UP
-8: vethYYYYYYY@if7: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
-    master docker0 state UP
+13: veth91835c2@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
+    master docker0 state UP ... link-netnsid 0
+14: veth6ea59a4@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
+    master docker0 state UP ... link-netnsid 1
 ```
 
-> "Two veth interfaces, both attached to docker0. These are the host-side ends of our veth pairs. The `@if5` and `@if7` tell us the interface index of the other end -- which is inside the container."
+> "Two veth interfaces, both attached to docker0. These are the host-side ends of our veth pairs. Notice the `@if2` on both -- that's the interface index of the other end inside each container. They're both `if2` because each container namespace has its own numbering -- `eth0` is always index 2 in there. The `link-netnsid` tells you which namespace each belongs to.
+>
+> So from the host side alone, you can't easily tell which veth belongs to which container. The trick is to look from the other direction -- from inside the container."
 
 **[Whiteboard annotation moment]** -- Switch to Excalidraw briefly and write the real veth names on the diagram next to the veth pair labels.
 
-> "You can also use the `bridge` command to see this."
-
-```bash
-bridge link
-```
-
-> "Now let's look inside one of the containers."
+> "Let's look inside c1 and match it up."
 
 ```bash
 docker exec c1 ip addr
@@ -119,11 +115,11 @@ docker exec c1 ip addr
 ```
 1: lo: <LOOPBACK,UP,LOWER_UP> ...
     inet 127.0.0.1/8 scope host lo
-5: eth0@if6: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
+2: eth0@if13: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
     inet 172.17.0.2/16 scope global eth0
 ```
 
-> "Inside the container, there's `eth0` -- that's the container-side end of the veth pair. Notice the interface index `@if6` -- that matches the host-side veth we saw earlier. And it has an IP on the 172.17.0.0/16 subnet."
+> "Inside the container, `eth0` is index 2 -- and `@if13` tells us the host-side peer is interface index 13. Look back at the host output -- index 13 is `veth91835c2`. That's our match. This is the reliable way to trace which veth belongs to which container: start inside the container, read the `@ifN`, and find that index on the host."
 
 ```bash
 docker exec c1 ip route

--- a/lessons/clab/00-docker-networking/solutions/README.md
+++ b/lessons/clab/00-docker-networking/solutions/README.md
@@ -17,32 +17,35 @@ The bridge IS the gateway -- packets from containers destined outside the subnet
 
 **How to match a host-side veth to its container-side eth0:**
 
-The `@ifN` index on each end references the other end. For example:
-- On the host: `vethXXXXXXX@if5` -- the `if5` means interface index 5 is the other end
-- In the container: `5: eth0@if6` -- the `if6` means interface index 6 is the host end
+Start from **inside the container** -- this is the reliable direction. Each container namespace has its own interface index numbering, so `eth0` is always index 2 in every container. That means the host-side `@if2` is the same for all containers and doesn't help you distinguish them.
 
-You can verify with:
+But the container's `@ifN` references the **host-side** index, which is globally unique:
+
+```bash
+# Inside c1
+docker exec c1 ip addr
+```
+
+```
+2: eth0@if13: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
+    inet 172.17.0.2/16 scope global eth0
+```
+
+The `@if13` tells you the host-side peer is interface index 13.
+
 ```bash
 # On the host
 ip link show master docker0
 ```
 
 ```
-6: veth1234567@if5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 ...
-    master docker0 state UP
+13: veth91835c2@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
+    master docker0 state UP ... link-netnsid 0
+14: veth6ea59a4@if2: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
+    master docker0 state UP ... link-netnsid 1
 ```
 
-```bash
-# In the container
-docker exec c1 ip addr
-```
-
-```
-5: eth0@if6: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
-    inet 172.17.0.2/16 scope global eth0
-```
-
-Interface index 6 on the host matches veth1234567, and interface index 5 in the container matches eth0. They are a pair.
+Index 13 is `veth91835c2` -- that's c1's veth pair. Both host-side veths show `@if2` because each namespace numbers `eth0` as index 2 independently. The `link-netnsid` (0 vs 1) identifies which namespace each belongs to, but reading `@ifN` from inside the container is the simplest way to trace the pair.
 
 **Default bridge subnet:** Typically `172.17.0.0/16`.
 


### PR DESCRIPTION
## Summary
- Fixed veth pair matching explanation to reflect real behavior -- host-side veths both show `@if2` because each namespace has independent index numbering
- Updated script, exercises, and solutions to teach the reliable direction: read `@ifN` from inside the container to find the host-side index

## Lesson(s) Affected
- `lessons/clab/00-docker-networking/` -- script.md, exercises, solutions

## Test plan
- [x] Verified against real `ip link show master docker0` and `docker exec ip addr` output
- [ ] Script expected output matches actual Docker behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)