### PR TITLE
Add iptables FORWARD rules to lesson 00 NAT section

### DIFF
--- a/lessons/clab/00-docker-networking/exercises/README.md
+++ b/lessons/clab/00-docker-networking/exercises/README.md
@@ -170,7 +170,7 @@ Complete Exercise 2 first (namespaces, bridge, and veth pairs must be in place).
    ```bash
    ip route show default
    ```
-   Note the interface name after `dev` (e.g., `eth0`, `enp0s3`, `wlan0`).
+   Note the interface name after `dev` (e.g., `enp6s0`, `enp0s3`, `wlan0`). On modern Linux this is **not** `eth0` -- use whatever your system shows.
 
 2. Add default routes in each namespace so they send non-local traffic to the bridge:
    ```bash
@@ -183,18 +183,24 @@ Complete Exercise 2 first (namespaces, bridge, and veth pairs must be in place).
    sudo sysctl -w net.ipv4.ip_forward=1
    ```
 
-4. Add a masquerade rule (replace `eth0` with your actual interface from step 1):
+4. Allow forwarding for br-study. Docker sets the FORWARD chain policy to DROP, which blocks our traffic:
    ```bash
-   sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -o eth0 -j MASQUERADE
+   sudo iptables -A FORWARD -i br-study -j ACCEPT
+   sudo iptables -A FORWARD -o br-study -j ACCEPT
    ```
 
-5. Test internet access from the namespaces:
+5. Add a masquerade rule (replace `enp6s0` with your actual interface from step 1):
+   ```bash
+   sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -o enp6s0 -j MASQUERADE
+   ```
+
+6. Test internet access from the namespaces:
    ```bash
    sudo ip netns exec red ping -c 3 8.8.8.8
    sudo ip netns exec blue ping -c 3 1.1.1.1
    ```
 
-6. Inspect Docker's own NAT rules for comparison:
+7. Inspect Docker's own NAT rules for comparison:
    ```bash
    sudo iptables -t nat -L POSTROUTING -v
    ```
@@ -203,6 +209,7 @@ Complete Exercise 2 first (namespaces, bridge, and veth pairs must be in place).
 
 - What does the masquerade rule actually do to each packet?
 - Why do we need IP forwarding enabled?
+- Why does Docker's FORWARD policy block our traffic, and what does Docker allow instead?
 - Can you find Docker's masquerade rule for the 172.17.0.0/16 subnet?
 
 ### Cleanup
@@ -211,7 +218,9 @@ Complete Exercise 2 first (namespaces, bridge, and veth pairs must be in place).
 sudo ip netns del red
 sudo ip netns del blue
 sudo ip link del br-study
-sudo iptables -t nat -D POSTROUTING -s 10.0.0.0/24 -o eth0 -j MASQUERADE
+sudo iptables -D FORWARD -i br-study -j ACCEPT
+sudo iptables -D FORWARD -o br-study -j ACCEPT
+sudo iptables -t nat -D POSTROUTING -s 10.0.0.0/24 -o enp6s0 -j MASQUERADE
 ```
 
 ---

--- a/lessons/clab/00-docker-networking/script.md
+++ b/lessons/clab/00-docker-networking/script.md
@@ -286,11 +286,22 @@ sudo ip netns exec red ping -c 2 10.0.0.254
 
 > **[VOICEOVER]**
 >
-> "Right now, if our red namespace tries to ping 8.8.8.8, it won't work. The packet would leave the namespace, reach the bridge, and then... nothing. The host doesn't know to forward it, and even if it did, the return traffic wouldn't know how to get back.
->
-> We need two things: IP forwarding and masquerading."
+> "Right now, if our red namespace tries to ping 8.8.8.8, it won't work. The packet would leave the namespace, reach the bridge, and then... nothing. We need to set up three things: IP forwarding, firewall rules to allow forwarding, and NAT masquerading."
 
-**Step 1: Add default routes in the namespaces**
+**Step 1: Find your outbound interface**
+
+```bash
+ip route show default
+```
+
+**Expected Output:**
+```
+default via 192.168.1.1 dev enp6s0 proto dhcp metric 100
+```
+
+> "First, we need to know the name of the host's outbound interface -- the one connected to the internet. It's the device name after `dev` in the default route. On modern Linux this is usually something like `enp6s0` or `wlan0`, not `eth0`. Remember this name -- we'll use it in the masquerade rule."
+
+**Step 2: Add default routes in the namespaces**
 
 ```bash
 sudo ip netns exec red ip route add default via 10.0.0.254
@@ -299,7 +310,7 @@ sudo ip netns exec blue ip route add default via 10.0.0.254
 
 > "Now the namespaces know to send non-local traffic to the bridge."
 
-**Step 2: Enable IP forwarding**
+**Step 3: Enable IP forwarding**
 
 ```bash
 sudo sysctl -w net.ipv4.ip_forward=1
@@ -307,18 +318,27 @@ sudo sysctl -w net.ipv4.ip_forward=1
 
 > "This tells the Linux kernel to forward packets between interfaces. Without this, the host drops any packet that isn't addressed to itself."
 
-**Step 3: Add the masquerade rule**
+**Step 4: Allow forwarding for our bridge**
 
 ```bash
-# Replace eth0 with your host's outbound interface (check with: ip route show default)
-sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -o eth0 -j MASQUERADE
+sudo iptables -A FORWARD -i br-study -j ACCEPT
+sudo iptables -A FORWARD -o br-study -j ACCEPT
 ```
 
-> "This NAT rule says: any packet from our 10.0.0.0/24 subnet leaving via the host's outbound interface should have its source IP rewritten to the host's IP. Return traffic gets translated back automatically.
->
-> This is exactly what Docker does. If you run `iptables -t nat -L`, you'll see Docker's own masquerade rules for the 172.17.0.0/16 subnet."
+> "This is important. Docker sets the iptables FORWARD chain policy to DROP -- it only allows forwarding for its own networks. Without these rules, our br-study traffic would be silently dropped before it ever reaches the NAT rule. You can check this yourself with `sudo iptables -L FORWARD -v` and you'll see the DROP policy."
 
-**Step 4: Test internet access**
+**Step 5: Add the masquerade rule**
+
+```bash
+# Replace enp6s0 with YOUR outbound interface from step 1
+sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -o enp6s0 -j MASQUERADE
+```
+
+> "This NAT rule says: any packet from our 10.0.0.0/24 subnet leaving via the outbound interface should have its source IP rewritten to the host's IP. Return traffic gets translated back automatically.
+>
+> This is exactly what Docker does. If you run `sudo iptables -t nat -L POSTROUTING -v`, you'll see Docker's own masquerade rules for the 172.17.0.0/16 subnet."
+
+**Step 6: Test internet access**
 
 ```bash
 sudo ip netns exec red ping -c 3 8.8.8.8
@@ -327,9 +347,9 @@ sudo ip netns exec red ping -c 3 8.8.8.8
 **Expected Output:**
 ```
 PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
-64 bytes from 8.8.8.8: icmp_seq=1 ttl=117 time=10.2 ms
-64 bytes from 8.8.8.8: icmp_seq=2 ttl=117 time=9.8 ms
-64 bytes from 8.8.8.8: icmp_seq=3 ttl=117 time=9.9 ms
+64 bytes from 8.8.8.8: icmp_seq=1 ttl=112 time=20.5 ms
+64 bytes from 8.8.8.8: icmp_seq=2 ttl=112 time=17.8 ms
+64 bytes from 8.8.8.8: icmp_seq=3 ttl=112 time=16.3 ms
 ```
 
 > "Our hand-built namespace can reach the internet -- just like a Docker container."
@@ -338,8 +358,9 @@ PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
 
 **Key Points:**
 - IP forwarding = kernel will route packets between interfaces
+- FORWARD chain = Docker sets it to DROP, so you must explicitly allow your bridge traffic
 - Masquerade = rewrite source IP for outbound traffic (SNAT)
-- Docker does both of these automatically
+- Docker does all three of these automatically
 
 ---
 
@@ -363,7 +384,9 @@ PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
 sudo ip netns del red
 sudo ip netns del blue
 sudo ip link del br-study
-sudo iptables -t nat -D POSTROUTING -s 10.0.0.0/24 -o eth0 -j MASQUERADE
+sudo iptables -D FORWARD -i br-study -j ACCEPT
+sudo iptables -D FORWARD -o br-study -j ACCEPT
+sudo iptables -t nat -D POSTROUTING -s 10.0.0.0/24 -o enp6s0 -j MASQUERADE
 ```
 
 > "Deleting the namespaces automatically removes the veth pairs that were inside them."

--- a/lessons/clab/00-docker-networking/solutions/README.md
+++ b/lessons/clab/00-docker-networking/solutions/README.md
@@ -167,10 +167,10 @@ ip route show default
 
 **Expected output (varies by system):**
 ```
-default via 192.168.1.1 dev eth0 proto dhcp metric 100
+default via 192.168.1.1 dev enp6s0 proto dhcp metric 100
 ```
 
-The interface is `eth0` (use whatever your system shows).
+The interface is `enp6s0` (use whatever your system shows -- on modern Linux this is usually **not** `eth0`).
 
 ```bash
 # 2. Add default routes
@@ -187,25 +187,31 @@ net.ipv4.ip_forward = 1
 ```
 
 ```bash
-# 4. Add masquerade rule (replace eth0 with your interface)
-sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -o eth0 -j MASQUERADE
+# 4. Allow forwarding for br-study
+sudo iptables -A FORWARD -i br-study -j ACCEPT
+sudo iptables -A FORWARD -o br-study -j ACCEPT
 ```
 
 ```bash
-# 5. Test internet access
+# 5. Add masquerade rule (replace enp6s0 with your interface)
+sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -o enp6s0 -j MASQUERADE
+```
+
+```bash
+# 6. Test internet access
 sudo ip netns exec red ping -c 3 8.8.8.8
 ```
 
 **Expected output:**
 ```
 PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
-64 bytes from 8.8.8.8: icmp_seq=1 ttl=117 time=10.2 ms
-64 bytes from 8.8.8.8: icmp_seq=2 ttl=117 time=9.8 ms
-64 bytes from 8.8.8.8: icmp_seq=3 ttl=117 time=9.9 ms
+64 bytes from 8.8.8.8: icmp_seq=1 ttl=112 time=20.5 ms
+64 bytes from 8.8.8.8: icmp_seq=2 ttl=112 time=17.8 ms
+64 bytes from 8.8.8.8: icmp_seq=3 ttl=112 time=16.3 ms
 ```
 
 ```bash
-# 6. Compare with Docker's rules
+# 7. Compare with Docker's rules
 sudo iptables -t nat -L POSTROUTING -v
 ```
 
@@ -213,7 +219,7 @@ sudo iptables -t nat -L POSTROUTING -v
 ```
 Chain POSTROUTING (policy ACCEPT)
  pkts bytes target     prot opt in     out     source               destination
-    3   252 MASQUERADE  all  --  any    eth0    10.0.0.0/24          anywhere
+    3   252 MASQUERADE  all  --  any    enp6s0  10.0.0.0/24          anywhere
     0     0 MASQUERADE  all  --  any    !docker0  172.17.0.0/16        anywhere
 ```
 
@@ -228,6 +234,23 @@ It rewrites the source IP address of outbound packets from 10.0.0.x to the host'
 **Why do we need IP forwarding?**
 
 Without `net.ipv4.ip_forward=1`, the Linux kernel drops any packet that arrives on one interface but is destined for another. It only processes packets addressed to its own IPs. IP forwarding tells the kernel to act as a router and forward packets between interfaces.
+
+**Why does Docker's FORWARD policy block our traffic?**
+
+Docker sets the FORWARD chain policy to DROP for security -- it only allows forwarding for traffic on its own networks (docker0 and any custom Docker networks). You can see this with:
+
+```bash
+sudo iptables -L FORWARD -v
+```
+
+```
+Chain FORWARD (policy DROP)
+ pkts bytes target     prot opt in     out     source               destination
+    0     0 DOCKER-USER  all  --  any    any     anywhere             anywhere
+    0     0 DOCKER-FORWARD  all  --  any    any     anywhere             anywhere
+```
+
+Our br-study traffic doesn't match any of Docker's FORWARD rules, so it hits the DROP policy. Adding explicit ACCEPT rules for br-study tells the kernel to allow forwarding for our bridge. Docker does this automatically for its own bridges -- we have to do it manually for ours.
 
 **Docker's masquerade rule:**
 

--- a/lessons/clab/00-docker-networking/tests/test_docker_networking.py
+++ b/lessons/clab/00-docker-networking/tests/test_docker_networking.py
@@ -186,6 +186,16 @@ class TestNAT:
             "Enable with: sudo sysctl -w net.ipv4.ip_forward=1"
         )
 
+    def test_forward_rules_exist(self):
+        """FORWARD chain should allow traffic for br-study."""
+        result = run_cmd("sudo iptables -L FORWARD -n")
+        assert "br-study" in result.stdout, (
+            "No FORWARD rule found for br-study. Docker sets FORWARD "
+            "policy to DROP, so you must explicitly allow br-study. "
+            "Add with: sudo iptables -A FORWARD -i br-study -j ACCEPT && "
+            "sudo iptables -A FORWARD -o br-study -j ACCEPT"
+        )
+
     def test_masquerade_rule_exists(self):
         """An iptables masquerade rule for 10.0.0.0/24 should exist."""
         result = run_cmd("sudo iptables -t nat -L POSTROUTING -n")


### PR DESCRIPTION
## Summary
- Added `iptables -A FORWARD` rules for br-study -- Docker sets the FORWARD policy to DROP, which silently blocks namespace traffic
- Made finding the correct outbound interface (`ip route show default`) a prominent first step instead of a parenthetical
- Replaced `eth0` with `enp6s0` as the example since modern Linux uses predictable interface names
- Added FORWARD rule test to test suite
- Updated cleanup commands in script, exercises, and solutions

## Lesson(s) Affected
- `lessons/clab/00-docker-networking/` -- script.md, exercises, solutions, tests

## Test plan
- [x] Verified fix on live system -- ping 8.8.8.8 from namespace now works
- [x] Confirmed Docker FORWARD policy is the root cause (`policy DROP` with 11 dropped packets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)