### PR TITLE
fix: align lessons 00 and 01 with lesson 02 quality standard

### DIFF
--- a/lessons/clab/00-docker-networking/README.md
+++ b/lessons/clab/00-docker-networking/README.md
@@ -123,6 +123,47 @@ A Linux bridge works like a virtual network switch. Docker's `docker0` bridge co
 
 For containers (or namespaces) to reach the internet, the host must forward packets and masquerade the source IP. Docker sets this up automatically with iptables rules. You can do the same manually with `iptables -t nat -A POSTROUTING ... -j MASQUERADE`.
 
+## Common Issues
+
+**Ping between namespaces fails:**
+
+Check each layer bottom-up:
+```bash
+# Are the interfaces UP?
+sudo ip netns exec red ip link show veth-r
+
+# Is the bridge UP?
+ip link show br-study
+
+# Are IPs assigned?
+sudo ip netns exec red ip addr show veth-r
+
+# Are veth pairs attached to the bridge?
+ip link show master br-study
+```
+
+**Internet access from namespaces fails but local ping works:**
+
+This is almost always a missing FORWARD rule or masquerade rule:
+```bash
+# Check FORWARD chain (Docker sets policy to DROP)
+sudo iptables -L FORWARD -v -n
+
+# Check masquerade rule exists
+sudo iptables -t nat -L POSTROUTING -v -n
+```
+
+**"Operation not permitted" errors:**
+
+Namespace operations require root. Use `sudo` for all `ip netns exec` commands:
+```bash
+# Wrong
+ip netns exec red ping 10.0.0.2
+
+# Correct
+sudo ip netns exec red ping 10.0.0.2
+```
+
 ## Exercises
 
 Complete the exercises in [exercises/README.md](exercises/README.md).

--- a/lessons/clab/00-docker-networking/exercises/README.md
+++ b/lessons/clab/00-docker-networking/exercises/README.md
@@ -2,6 +2,10 @@
 
 Complete these exercises to reinforce your understanding of the Linux primitives under container networking.
 
+```bash
+cd lessons/clab/00-docker-networking
+```
+
 ## Exercise 1: Inspect Docker's Network Plumbing
 
 **Objective:** Trace the Linux components Docker creates when you run containers.
@@ -41,11 +45,12 @@ Complete these exercises to reinforce your understanding of the Linux primitives
    docker network inspect bridge
    ```
 
-### Questions
+### Deliverables
 
-- What is the IP of the `docker0` bridge? How does it relate to the container's default gateway?
-- How can you match a host-side veth to its container-side eth0? (Hint: start from inside the container)
-- What subnet does Docker use for the default bridge?
+Create a file `exercises/exercise1-answers.md` with:
+- The IP of the `docker0` bridge and how it relates to the container's default gateway
+- A step-by-step explanation of how to match a host-side veth to its container-side eth0 (hint: start from inside the container)
+- The subnet Docker uses for the default bridge
 
 ### Cleanup
 
@@ -140,11 +145,12 @@ docker rm -f c1 c2
    sudo ip netns exec red ping -c 2 10.0.0.254
    ```
 
-### Questions
+### Deliverables
 
+Document in `exercises/exercise2-answers.md`:
 - What happens if you skip bringing up the loopback (`lo`)? Try it and see.
-- What do you see when you run `ip link show master br-study` on the host?
-- How is this different from what Docker does with `docker0`?
+- The output of `ip link show master br-study` on the host, and what each line means
+- A comparison: how is your manual setup different from what Docker does with `docker0`? (Hint: Docker automates these exact steps)
 
 ### Cleanup
 
@@ -205,12 +211,13 @@ Complete Exercise 2 first (namespaces, bridge, and veth pairs must be in place).
    sudo iptables -t nat -L POSTROUTING -v
    ```
 
-### Questions
+### Deliverables
 
-- What does the masquerade rule actually do to each packet?
+Document in `exercises/exercise3-answers.md`:
+- What does the masquerade rule actually do to each packet? (Describe the source IP rewriting)
 - Why do we need IP forwarding enabled?
 - Why does Docker's FORWARD policy block our traffic, and what does Docker allow instead?
-- Can you find Docker's masquerade rule for the 172.17.0.0/16 subnet?
+- The output of `sudo iptables -t nat -L POSTROUTING -v` -- can you find Docker's masquerade rule for 172.17.0.0/16?
 
 ### Cleanup
 
@@ -222,6 +229,84 @@ sudo iptables -D FORWARD -i br-study -j ACCEPT
 sudo iptables -D FORWARD -o br-study -j ACCEPT
 sudo iptables -t nat -D POSTROUTING -s 10.0.0.0/24 -o enp6s0 -j MASQUERADE
 ```
+
+---
+
+## Exercise 4: Break/Fix -- Bridge Down
+
+**Objective:** Diagnose why namespaces lose connectivity when the bridge is down.
+
+### Prerequisites
+
+Complete Exercise 2 first (namespaces, bridge, and veth pairs must be in place).
+
+### Setup (break it)
+
+```bash
+sudo ip link set br-study down
+```
+
+### Symptom
+
+```bash
+sudo ip netns exec red ping -c 2 10.0.0.2
+# FAILS -- no response or "Network is unreachable"
+```
+
+### Your Task
+
+1. Check the bridge state: `ip link show br-study`. What does `state DOWN` mean?
+2. Check if the veth pairs are still attached: `ip link show master br-study`
+3. Fix the bridge and verify ping works again.
+
+### Deliverables
+
+Document:
+- The commands you used to diagnose the problem
+- What "state DOWN" on a bridge means for all attached interfaces
+- Your fix and verification
+
+---
+
+## Exercise 5: Break/Fix -- Missing Masquerade
+
+**Objective:** Diagnose why namespaces can reach each other but not the internet.
+
+### Prerequisites
+
+Complete Exercises 2 and 3 (full NAT setup must be in place).
+
+### Setup (break it)
+
+```bash
+sudo iptables -t nat -D POSTROUTING -s 10.0.0.0/24 -o enp6s0 -j MASQUERADE
+```
+
+(Replace `enp6s0` with your actual outbound interface.)
+
+### Symptom
+
+```bash
+# This works (same subnet, local bridge)
+sudo ip netns exec red ping -c 2 10.0.0.2
+
+# This fails (internet)
+sudo ip netns exec red ping -c 2 -W 3 8.8.8.8
+```
+
+### Your Task
+
+1. Verify that local connectivity still works (red to blue, red to bridge)
+2. Check the NAT table: `sudo iptables -t nat -L POSTROUTING -v -n`. What's missing?
+3. Explain why local traffic works but internet traffic doesn't -- what does masquerade do that local bridging doesn't need?
+4. Fix by re-adding the masquerade rule and verify internet access.
+
+### Deliverables
+
+Explain:
+- Why removing the masquerade rule breaks internet access but not local connectivity
+- What masquerade does to the source IP of outbound packets
+- How return traffic finds its way back to the namespace
 
 ---
 
@@ -283,6 +368,8 @@ pytest tests/ -v
 - [ ] Exercise 1: Inspected Docker's bridge, veth pairs, and container networking
 - [ ] Exercise 2: Built a namespace network from scratch with ping working
 - [ ] Exercise 3: Enabled NAT and reached the internet from a namespace
+- [ ] Exercise 4: Diagnosed and fixed a downed bridge
+- [ ] Exercise 5: Diagnosed and fixed missing masquerade rule
 - [ ] Bonus: Explored Docker Compose's bridge network
 
 ## Next Steps

--- a/lessons/clab/00-docker-networking/solutions/README.md
+++ b/lessons/clab/00-docker-networking/solutions/README.md
@@ -263,6 +263,77 @@ This masquerades traffic from containers (172.17.0.0/16) going out any interface
 
 ---
 
+## Exercise 4: Break/Fix -- Bridge Down
+
+**Diagnosis:**
+
+```bash
+ip link show br-study
+```
+
+```
+5: br-study: <BROADCAST,MULTICAST> mtu 1500 ...
+    link/ether 42:65:a1:xx:xx:xx brd ff:ff:ff:ff:ff:ff
+```
+
+Notice the flags: `<BROADCAST,MULTICAST>` without `UP`. When the bridge is up, it shows `<BROADCAST,MULTICAST,UP,LOWER_UP>`. A down bridge cannot forward frames between its ports -- it's like unplugging a switch.
+
+The veth pairs are still attached (`ip link show master br-study` still lists them), but traffic can't flow through the bridge.
+
+**Fix:**
+
+```bash
+sudo ip link set br-study up
+```
+
+**Verification:**
+
+```bash
+sudo ip netns exec red ping -c 2 10.0.0.2
+```
+
+**Key lesson:** A Linux bridge must be UP to forward traffic. Even if all veth pairs are correctly attached and all interfaces inside namespaces have IPs, a downed bridge stops all communication. This is the virtual equivalent of a switch losing power.
+
+---
+
+## Exercise 5: Break/Fix -- Missing Masquerade
+
+**Diagnosis:**
+
+```bash
+sudo iptables -t nat -L POSTROUTING -v -n
+```
+
+```
+Chain POSTROUTING (policy ACCEPT)
+ pkts bytes target     prot opt in     out     source               destination
+    0     0 MASQUERADE  all  --  *      !docker0  172.17.0.0/16        0.0.0.0/0
+```
+
+Only Docker's masquerade rule is present. Our rule for 10.0.0.0/24 is gone.
+
+**Why local works but internet doesn't:**
+
+Local traffic (red to blue, red to bridge) stays on the br-study bridge. It never leaves the host, so it never needs NAT. The bridge forwards frames based on MAC addresses -- this is pure Layer 2 switching.
+
+Internet traffic must leave the host via the outbound interface (e.g., enp6s0). Without masquerade, the source IP is 10.0.0.1 -- a private, non-routable address. The ISP's routers don't know how to send replies back to 10.0.0.1, so the traffic is silently dropped. Masquerade rewrites the source IP to the host's public IP, and the kernel tracks the mapping so return traffic gets translated back.
+
+**Fix:**
+
+```bash
+sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -o enp6s0 -j MASQUERADE
+```
+
+**Verification:**
+
+```bash
+sudo ip netns exec red ping -c 3 8.8.8.8
+```
+
+**Key lesson:** Masquerade (SNAT) is only needed when traffic crosses a network boundary -- from private addresses to the internet. Local bridge traffic doesn't need NAT because both endpoints are directly reachable at Layer 2.
+
+---
+
 ## Key Takeaways
 
 1. **Network namespaces** are what isolate container networking -- each container gets its own

--- a/lessons/clab/01-containerlab-primer/README.md
+++ b/lessons/clab/01-containerlab-primer/README.md
@@ -172,7 +172,7 @@ docker ps | grep clab
 
 ```mermaid
 graph LR
-    srl1[srl1<br/>SR Linux] -- e1-1 --- e1-1 --- srl2[srl2<br/>SR Linux]
+    srl1[srl1<br/>SR Linux<br/>24.10.1] -- "e1-1 ---- e1-1" --- srl2[srl2<br/>SR Linux<br/>24.10.1]
 ```
 
 ## Files in This Lesson
@@ -233,6 +233,15 @@ docker ps | grep clab
 
 # Check container logs
 docker logs clab-first-lab-srl1
+```
+
+**Interfaces show "down" after deploy:**
+
+SR Linux takes 15-30 seconds to fully boot. Wait and re-check:
+```bash
+# Wait, then verify
+sleep 20
+docker exec -it clab-first-lab-srl1 sr_cli -c "show interface brief"
 ```
 
 ## What's Next

--- a/lessons/clab/01-containerlab-primer/exercises/README.md
+++ b/lessons/clab/01-containerlab-primer/exercises/README.md
@@ -2,6 +2,10 @@
 
 Complete these exercises to solidify your containerlab skills.
 
+```bash
+cd lessons/clab/01-containerlab-primer
+```
+
 ## Exercise 1: Deploy and Explore
 
 **Objective:** Deploy the lab topology and explore the running environment.
@@ -41,6 +45,7 @@ Create a file `exercises/exercise1-output.md` with:
 - Output of `containerlab inspect`
 - SR Linux version from `show version`
 - List of interfaces from `show interface brief`
+- Your explanation: why is `ethernet-1/1` showing `oper: up` while other ethernet interfaces show `oper: down`?
 
 ---
 
@@ -165,7 +170,7 @@ Create `exercises/resources.md` with:
    ```yaml
    host1:
      kind: linux
-     image: alpine:latest
+     image: alpine:3.20
    ```
 
 3. Deploy and verify both containers are running
@@ -191,6 +196,108 @@ graph LR
 
 - `exercises/mixed-topology.clab.yml`
 - Verification that `eth1` exists in the Alpine container
+
+---
+
+## Exercise 6: Break/Fix -- Container Stopped
+
+**Objective:** Diagnose why a node is unreachable when its container has stopped.
+
+### Setup (break it)
+
+First, make sure the two-node lab is running:
+
+```bash
+cd lessons/clab/01-containerlab-primer
+containerlab deploy -t topology/lab.clab.yml
+```
+
+Now stop one of the containers:
+
+```bash
+docker stop clab-first-lab-srl2
+```
+
+### Symptom
+
+```bash
+# Try to connect to srl2
+docker exec -it clab-first-lab-srl2 sr_cli
+# ERROR: container is not running
+
+# Inspect shows something wrong
+containerlab inspect -t topology/lab.clab.yml
+# srl2 shows state: "exited" instead of "running"
+```
+
+### Your Task
+
+1. **Diagnose:** Run `containerlab inspect` and identify which node is down. Check `docker ps -a --filter name=clab-first-lab` to see stopped containers.
+2. **Fix:** Restart the stopped container and verify it returns to a running state.
+3. **Verify:** Connect to srl2 with `docker exec` and confirm `show interface brief` shows `ethernet-1/1` as up.
+
+### Deliverables
+
+Document:
+- The commands you used to diagnose the problem
+- How you fixed it (hint: `docker start` vs. redeploying the lab)
+- Why `docker ps` alone wouldn't show the stopped container (you need `-a`)
+
+---
+
+## Exercise 7: Break/Fix -- Missing Link
+
+**Objective:** Diagnose why two nodes cannot see each other when a link is missing from the topology.
+
+### Setup (break it)
+
+1. Destroy the current lab:
+   ```bash
+   containerlab destroy -t topology/lab.clab.yml --cleanup
+   ```
+
+2. Create a broken topology file `exercises/broken-topology.clab.yml`:
+   ```yaml
+   name: broken-lab
+
+   topology:
+     nodes:
+       srl1:
+         kind: srl
+         image: ghcr.io/nokia/srlinux:24.10.1
+
+       srl2:
+         kind: srl
+         image: ghcr.io/nokia/srlinux:24.10.1
+
+     links: []
+   ```
+
+3. Deploy the broken topology:
+   ```bash
+   containerlab deploy -t exercises/broken-topology.clab.yml
+   ```
+
+### Symptom
+
+Both containers are running, but:
+
+```bash
+docker exec -it clab-broken-lab-srl1 sr_cli -c "show interface brief"
+# ethernet-1/1 shows "down" (no link partner)
+```
+
+### Your Task
+
+1. **Diagnose:** Both nodes are running, so it's not a container problem. Check `show interface brief` on both nodes -- what's different from the working lab?
+2. **Explain:** Why does `ethernet-1/1` show `oper: down`? What's missing?
+3. **Fix:** Destroy the broken lab, add the missing link to the topology file, and redeploy.
+4. **Verify:** Confirm `ethernet-1/1` is now `oper: up` on both nodes.
+
+### Deliverables
+
+- Your fixed `exercises/broken-topology.clab.yml`
+- Explanation of the difference between a node being "running" and an interface being "up"
 
 ---
 
@@ -221,6 +328,8 @@ pytest tests/ -v
 - [ ] Exercise 3: Generated topology graph and JSON output
 - [ ] Exercise 4: Found documentation and community resources
 - [ ] Exercise 5: Created mixed network/Linux topology
+- [ ] Exercise 6: Diagnosed and fixed a stopped container
+- [ ] Exercise 7: Diagnosed and fixed a missing link
 
 ## Next Steps
 

--- a/lessons/clab/01-containerlab-primer/script.md
+++ b/lessons/clab/01-containerlab-primer/script.md
@@ -20,7 +20,7 @@
 - [ ] Terminal font size increased (14-16pt)
 - [ ] Notifications disabled
 - [ ] Clean terminal: `clear && history -c`
-- [ ] No labs running: `sudo containerlab destroy --all`
+- [ ] No labs running: `containerlab destroy --all`
 
 ---
 

--- a/lessons/clab/01-containerlab-primer/solutions/README.md
+++ b/lessons/clab/01-containerlab-primer/solutions/README.md
@@ -2,6 +2,58 @@
 
 Reference solutions for the Containerlab Primer exercises.
 
+## Exercise 1: Deploy and Explore
+
+**`containerlab inspect` output:**
+
+```
++---+---------------------+--------------+-------------------------------+------+---------+----------------+----------------------+
+| # |        Name         | Container ID |             Image             | Kind |  State  |  IPv4 Address  |     IPv6 Address     |
++---+---------------------+--------------+-------------------------------+------+---------+----------------+----------------------+
+| 1 | clab-first-lab-srl1 | abc123def456 | ghcr.io/nokia/srlinux:24.10.1 | srl  | running | 172.20.20.2/24 | 2001:172:20:20::2/64 |
+| 2 | clab-first-lab-srl2 | 789ghi012jkl | ghcr.io/nokia/srlinux:24.10.1 | srl  | running | 172.20.20.3/24 | 2001:172:20:20::3/64 |
++---+---------------------+--------------+-------------------------------+------+---------+----------------+----------------------+
+```
+
+The IPv4 Address column shows the management IP that containerlab assigns automatically. These are on the management network (172.20.20.0/24), separate from any data-plane interfaces. You'll use pinned management IPs in Lesson 2 for Ansible.
+
+**`show version` output (inside srl1):**
+
+```
+A:srl1# show version
+--------------------------------------------------
+Hostname          : srl1
+Chassis Type      : 7220 IXR-D2L
+Part Number       : Sim Part No.
+Serial Number     : Sim Serial No.
+System HW MAC Address: 1A:2B:00:00:00:00
+Software Version  : v24.10.1
+Build Number      : 000-000000
+Architecture      : x86_64
+Last Booted       : 2026-02-28T12:00:00.000Z
+Total Memory      : 24052875 kB
+Free Memory       : 18234567 kB
+--------------------------------------------------
+```
+
+**`show interface brief` output:**
+
+```
+A:srl1# show interface brief
++---------------------+----------+----------+--------+----------+
+|      Interface      |  Admin   |  Oper    | Speed  |   Type   |
++=====================+==========+==========+========+==========+
+| ethernet-1/1        | enable   | up       | 25G    | ethernet |
+| ethernet-1/2        | enable   | down     | 25G    | ethernet |
+| ...                 |          |          |        |          |
+| mgmt0               | enable   | up       | 1G     | None     |
++---------------------+----------+----------+--------+----------+
+```
+
+Only `ethernet-1/1` is operationally up because that's the only interface with a link (connected to srl2). The rest show `down` because nothing is plugged into them. The `mgmt0` interface is the management port containerlab uses.
+
+---
+
 ## Exercise 2: Three-Node Topology
 
 **File: `three-node.clab.yml`**
@@ -39,6 +91,44 @@ Expected output shows both `ethernet-1/1` and `ethernet-1/2`.
 
 ---
 
+## Exercise 3: Generate Documentation
+
+**Topology graph:**
+
+The `containerlab graph` command generates an HTML page with an interactive topology diagram. In headless environments, use the `--drawio` flag to export a Draw.io file instead.
+
+```bash
+containerlab graph -t exercises/three-node.clab.yml --drawio
+```
+
+This creates a `.drawio` file in the current directory that you can open in [draw.io](https://app.diagrams.net/).
+
+**JSON inspect output:**
+
+```bash
+containerlab inspect -t exercises/three-node.clab.yml --format json > exercises/lab-info.json
+```
+
+The JSON output contains structured data for each node including container ID, image, kind, state, and management IP. This format is useful for automation -- you can parse it with `jq` or Python to build scripts that interact with your lab programmatically.
+
+```json
+{
+  "containers": [
+    {
+      "name": "clab-three-node-lab-srl1",
+      "container_id": "abc123",
+      "image": "ghcr.io/nokia/srlinux:24.10.1",
+      "kind": "srl",
+      "state": "running",
+      "ipv4_address": "172.20.20.2/24"
+    },
+    ...
+  ]
+}
+```
+
+---
+
 ## Exercise 4: Resources
 
 **SR Linux Documentation:**
@@ -71,7 +161,7 @@ topology:
 
     host1:
       kind: linux
-      image: alpine:latest
+      image: alpine:3.20
 
   links:
     - endpoints: ["router:e1-1", "host1:eth1"]
@@ -104,12 +194,79 @@ Note: The interface exists but has no IP address assigned. That's normal - we'll
 
 ---
 
+## Exercise 6: Break/Fix -- Container Stopped
+
+**Diagnosis:**
+
+```bash
+containerlab inspect -t topology/lab.clab.yml
+```
+
+The inspect output shows srl2 with state `exited` instead of `running`.
+
+```bash
+docker ps -a --filter name=clab-first-lab
+```
+
+```
+CONTAINER ID   IMAGE                          COMMAND   STATE    NAMES
+abc123         ghcr.io/nokia/srlinux:24.10.1  ...       Up      clab-first-lab-srl1
+def456         ghcr.io/nokia/srlinux:24.10.1  ...       Exited  clab-first-lab-srl2
+```
+
+The `-a` flag is critical -- `docker ps` without it only shows running containers, so the stopped srl2 would be invisible. This is a common gotcha.
+
+**Fix:**
+
+```bash
+docker start clab-first-lab-srl2
+```
+
+Wait 10-15 seconds for SR Linux to boot, then verify:
+
+```bash
+docker exec -it clab-first-lab-srl2 sr_cli -c "show interface brief"
+```
+
+`ethernet-1/1` should show `oper: up` because the link to srl1 is re-established.
+
+Alternatively, you could destroy and redeploy the entire lab with `containerlab deploy`. `docker start` is faster for a single node, but redeploying guarantees a clean state.
+
+---
+
+## Exercise 7: Break/Fix -- Missing Link
+
+**Diagnosis:**
+
+Both containers are running (`docker ps` shows them), but `show interface brief` on both nodes shows `ethernet-1/1` as `oper: down`. In the working lab, this interface was `oper: up`.
+
+The topology file has `links: []` -- no virtual links are created between the nodes. Without a link, there's no veth pair connecting the interfaces, so the operational state stays down.
+
+This is the containerlab equivalent of a missing cable. The node is fine, the interface exists, but nothing is plugged into it.
+
+**Fix:**
+
+Add the missing link to `exercises/broken-topology.clab.yml`:
+
+```yaml
+  links:
+    - endpoints: ["srl1:e1-1", "srl2:e1-1"]
+```
+
+```bash
+containerlab destroy -t exercises/broken-topology.clab.yml --cleanup
+containerlab deploy -t exercises/broken-topology.clab.yml
+```
+
+**Key lesson:** A container being "running" only means the process is alive. An interface being "up" requires a link partner on the other end. Always check both the node state AND the interface state when troubleshooting.
+
+---
+
 ## Key Takeaways
 
-1. **Topology files are YAML** - Easy to read, version control, and template
-2. **Lab names matter** - They're used in container names: `clab-<name>-<node>`
-3. **Interface naming:**
-   - SR Linux: `e1-1` = `ethernet-1/1`
-   - Linux: `eth1`, `eth2`, etc.
-4. **Mixed topologies work** - Combine network OS and standard Linux containers
-5. **Inspect is your friend** - Always verify what's running with `containerlab inspect`
+1. **Topology files are YAML** -- this means you can version-control your network labs in Git, diff changes between versions, and template them for different environments
+2. **Lab names drive container names** -- the pattern `clab-<name>-<node>` is how you'll `docker exec` into devices; pick short, meaningful names so your commands stay readable
+3. **Interface naming maps between shorthand and full names** -- `e1-1` in the topology file becomes `ethernet-1/1` inside SR Linux; Linux hosts use `eth1`, `eth2`, etc. Understanding this mapping avoids confusion when troubleshooting
+4. **Mixed topologies bridge network OS and Linux** -- combining SR Linux routers with Alpine hosts lets you simulate real scenarios where applications (in Linux) communicate through network infrastructure
+5. **`containerlab inspect` is your first troubleshooting command** -- it shows state, management IPs, and container IDs; always run it before debugging individual nodes
+6. **Pin image versions for reproducibility** -- `alpine:3.20` not `alpine:latest`; a lab that works today should work identically next month

--- a/lessons/clab/01-containerlab-primer/solutions/mixed-topology.clab.yml
+++ b/lessons/clab/01-containerlab-primer/solutions/mixed-topology.clab.yml
@@ -11,7 +11,7 @@ topology:
     # Standard Alpine Linux host
     host1:
       kind: linux
-      image: alpine:latest
+      image: alpine:3.20
 
   links:
     # Connect router's e1-1 to host's eth1

--- a/lessons/clab/01-containerlab-primer/tests/test_lab.py
+++ b/lessons/clab/01-containerlab-primer/tests/test_lab.py
@@ -76,9 +76,9 @@ class TestTopologyStructure:
             return yaml.safe_load(f)
 
     def test_has_name(self, topology):
-        """Topology should have a name."""
+        """Topology should have the expected name."""
         assert "name" in topology
-        assert len(topology["name"]) > 0
+        assert topology["name"] == "first-lab"
 
     def test_has_nodes(self, topology):
         """Topology should define nodes."""
@@ -108,6 +108,13 @@ class TestTopologyStructure:
         for i, link in enumerate(links):
             assert "endpoints" in link, f"Link {i} missing 'endpoints'"
             assert len(link["endpoints"]) == 2, f"Link {i} should have exactly 2 endpoints"
+
+    def test_no_latest_tags(self, topology):
+        """No node should use 'latest' image tag."""
+        nodes = topology["topology"]["nodes"]
+        for name, config in nodes.items():
+            image = config.get("image", "")
+            assert "latest" not in image, f"Node {name} uses 'latest' tag -- pin a specific version"
 
 
 class TestLabDeployment:
@@ -146,7 +153,7 @@ class TestLabDeployment:
         containers = result.stdout.strip().split('\n')
         containers = [c for c in containers if c]  # Remove empty strings
 
-        assert len(containers) >= 2, f"Expected at least 2 containers, got: {containers}"
+        assert len(containers) == 2, f"Expected 2 containers, got: {containers}"
 
     def test_inspect_returns_data(self):
         """containerlab inspect should return lab information."""
@@ -182,7 +189,7 @@ class TestLabDeployment:
 
 
 class TestExerciseFiles:
-    """Verify exercise solution files exist (if completed)."""
+    """Verify exercise solution files exist and are valid."""
 
     def test_solutions_directory_exists(self):
         """Solutions directory should exist."""
@@ -196,12 +203,23 @@ class TestExerciseFiles:
 
         for clab_file in solutions_dir.glob("*.clab.yml"):
             with open(clab_file) as f:
-                try:
-                    data = yaml.safe_load(f)
-                    assert data is not None, f"Empty file: {clab_file}"
-                    assert "topology" in data, f"Missing topology key: {clab_file}"
-                except yaml.YAMLError as e:
-                    pytest.fail(f"Invalid YAML in {clab_file}: {e}")
+                data = yaml.safe_load(f)
+                assert data is not None, f"Empty file: {clab_file}"
+                assert "topology" in data, f"Missing topology key: {clab_file}"
+
+    def test_solution_topologies_no_latest_tags(self):
+        """Solution topology files should not use 'latest' image tags."""
+        import yaml
+        solutions_dir = LESSON_DIR / "solutions"
+
+        for clab_file in solutions_dir.glob("*.clab.yml"):
+            with open(clab_file) as f:
+                data = yaml.safe_load(f)
+                if data and "topology" in data and "nodes" in data["topology"]:
+                    for name, config in data["topology"]["nodes"].items():
+                        image = config.get("image", "")
+                        assert "latest" not in image, \
+                            f"{clab_file.name}: node {name} uses 'latest' tag"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Brings lessons 00 and 01 up to the quality and rigor established in lesson 02
- Fixes `alpine:latest` violations in lesson 01 (exercises, solutions, topology file)
- Adds break/fix exercises to both lessons (2 per lesson, following lesson 02's Setup/Symptom/Task pattern)
- Adds missing solutions, deliverables blocks, Common Issues sections, and improved test coverage

## Lesson 00 Changes
- Add Common Issues section to README (3 troubleshooting scenarios)
- Add deliverables blocks to exercises 1, 2, 3 (ask for understanding, not just output)
- Add break/fix exercises 4 (bridge down) and 5 (missing masquerade) with solutions
- Add `cd` context at top of exercises

## Lesson 01 Changes
- Fix `alpine:latest` to `alpine:3.20` in 3 files
- Add solutions for exercises 1 (deploy/explore output) and 3 (graph/JSON)
- Add break/fix exercises 6 (container stopped) and 7 (missing link) with solutions
- Improve Key Takeaways with conceptual "why" explanations
- Fix Mermaid diagram rendering in README
- Add SR Linux boot time to Common Issues
- Fix `sudo containerlab` inconsistency in script.md
- Add `test_no_latest_tags`, fix `>= 2` to `== 2`, add exact name assertion, add solution file tag validation

## Test plan
- [ ] Lesson 01 topology files pass `test_no_latest_tags`
- [ ] Solution topology files pass `test_solution_topologies_no_latest_tags`
- [ ] All existing tests still pass
- [ ] Break/fix exercises follow lesson 02's Setup/Symptom/Task pattern
- [ ] No `alpine:latest` references remain in lesson 01

🤖 Generated with [Claude Code](https://claude.com/claude-code)