### PR TITLE
fix: rewrite sync workflow to use independent main history

### DIFF
--- a/.github/workflows/sync-student-branch.yml
+++ b/.github/workflows/sync-student-branch.yml
@@ -4,6 +4,10 @@
 # The .admin-files manifest (in repo root) lists patterns to remove.
 # main = student-facing view (clean, no instructor content)
 # instructor = full working branch (student + instructor content)
+#
+# Uses the "gh-pages pattern": main has its own independent commit history
+# (no shared ancestry with instructor) so GitHub never shows misleading
+# ahead/behind counts between the two branches.
 
 name: Sync student branch
 
@@ -23,43 +27,75 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: instructor
-          fetch-depth: 0
+          path: source
 
-      - name: Remove admin-only files
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: target
+        continue-on-error: true
+
+      - name: Build filtered student view
         run: |
+          # Start with a clean copy of instructor content (excluding .git)
+          rsync -a --exclude='.git' source/ target/
+
+          cd target
+
           # Read .admin-files manifest and remove matching files
-          while IFS= read -r pattern; do
-            # Skip comments and blank lines
-            [[ "$pattern" =~ ^[[:space:]]*#.*$ || -z "${pattern// }" ]] && continue
+          if [ -f .admin-files ]; then
+            while IFS= read -r pattern; do
+              # Skip comments and blank lines
+              [[ "$pattern" =~ ^[[:space:]]*#.*$ || -z "${pattern// }" ]] && continue
 
-            # Use git ls-files for glob patterns, fall back to find
-            files=$(git ls-files "$pattern" 2>/dev/null)
-            if [ -z "$files" ]; then
-              files=$(find . -path "./$pattern" -o -path "./$pattern*" 2>/dev/null | sed 's|^\./||')
-            fi
-
-            if [ -n "$files" ]; then
-              echo "Removing pattern '$pattern':"
-              echo "$files" | while IFS= read -r f; do
-                echo "  - $f"
-                rm -rf "$f"
+              # Expand glob and remove matches
+              # Use bash globbing with nullglob to handle patterns safely
+              shopt -s globstar nullglob
+              matched=0
+              for f in $pattern; do
+                if [ -e "$f" ]; then
+                  echo "  - $f"
+                  rm -rf "$f"
+                  matched=1
+                fi
               done
-            fi
-          done < .admin-files
+              shopt -u globstar nullglob
 
-          # Also remove the workflow itself and .admin-files from the student branch
+              if [ "$matched" -eq 1 ]; then
+                echo "Removed pattern '$pattern'"
+              fi
+            done < .admin-files
+          fi
+
+          # Remove the workflow itself and .admin-files from the student branch
           rm -rf .github/workflows/sync-student-branch.yml
           rm -f .admin-files
 
           # Clean up empty directories left behind
           find . -type d -empty -not -path './.git/*' -delete 2>/dev/null || true
 
-      - name: Force-push to main
+      - name: Commit and force-push to main
         run: |
+          cd target
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add -A
-          git commit -m "sync: update student branch from instructor" --allow-empty
+          # If main didn't exist yet, initialize a fresh orphan branch
+          if [ ! -d .git ]; then
+            git init
+            git checkout --orphan main
+          fi
 
-          git push --force origin HEAD:main
+          git add -A
+
+          # Only commit and push if there are actual changes
+          if git diff --cached --quiet; then
+            echo "No changes to sync"
+          else
+            SHORT_SHA=$(cd ../source && git rev-parse --short HEAD)
+            git commit -m "sync: update student branch from instructor@${SHORT_SHA}"
+            git push --force "https://x-access-token:${GITHUB_TOKEN}" HEAD:main
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Rewrites the instructor-to-main sync workflow using the "gh-pages pattern"
- Uses two separate checkouts (`source/` for instructor, `target/` for main) so main maintains its own independent commit lineage
- Eliminates the misleading "instructor is 1 commit behind main" message caused by the sync commit living on shared history

## What changed
- **Two checkouts** instead of one — keeps `.git` histories separate
- **rsync + delete** instead of in-place removal — builds student view in main's working tree
- **Orphan bootstrap** — handles the case where main doesn't exist yet
- **Skip no-op pushes** — avoids empty commits when only admin files changed
- **Source SHA in commit message** — `instructor@<sha>` for traceability

## Test plan
- [ ] Merge to instructor and verify the workflow runs successfully
- [ ] Confirm main contains only student-facing files (no script.md, CLAUDE.md, etc.)
- [ ] Confirm GitHub no longer shows "instructor is behind main"
- [ ] Verify `git log main` shows independent commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)