### PR TITLE
fix: quote descriptions in lesson 02 solution CLI commands

### DIFF
--- a/lessons/clab/02-ip-fundamentals/solutions/README.md
+++ b/lessons/clab/02-ip-fundamentals/solutions/README.md
@@ -65,13 +65,13 @@ interfaces:
 enter candidate
 set / interface ethernet-1/1 admin-state enable
 set / interface ethernet-1/1 subinterface 0 admin-state enable
-set / interface ethernet-1/1 subinterface 0 description Link to srl1
+set / interface ethernet-1/1 subinterface 0 description 'Link to srl1'
 set / interface ethernet-1/1 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/1 subinterface 0 ipv4 address 10.1.2.2/24
 set / network-instance default interface ethernet-1/1.0
 set / interface ethernet-1/2 admin-state enable
 set / interface ethernet-1/2 subinterface 0 admin-state enable
-set / interface ethernet-1/2 subinterface 0 description Link to host2
+set / interface ethernet-1/2 subinterface 0 description 'Link to host2'
 set / interface ethernet-1/2 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/2 subinterface 0 ipv4 address 10.1.3.1/24
 set / network-instance default interface ethernet-1/2.0


### PR DESCRIPTION
## Summary
- Adds single quotes around description values in the Exercise 2 solution's generated CLI commands
- Matches what the Jinja2 template (`srl_interfaces.json.j2`) actually produces
- SR Linux CLI requires quoting values with spaces

## Test plan
- [ ] Compare solution CLI output with template rendering — descriptions should be quoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)