### PR TITLE
fix: rebuild main when parentage structure changes

### DIFF
--- a/.github/workflows/sync-student-branch.yml
+++ b/.github/workflows/sync-student-branch.yml
@@ -81,10 +81,12 @@ jobs:
           # Previous main tip is also a parent (for linear main history)
           MAIN_TIP=$(git rev-parse --verify refs/remotes/origin/main 2>/dev/null || true)
 
-          # Check if tree actually changed
+          # Check if tree AND parentage are both unchanged
           if [ -n "$MAIN_TIP" ]; then
             OLD_TREE=$(git rev-parse "${MAIN_TIP}^{tree}" 2>/dev/null || true)
-            if [ "$NEW_TREE" = "$OLD_TREE" ]; then
+            # Check if instructor HEAD is already a parent of main tip
+            ALREADY_PARENT=$(git rev-parse "${MAIN_TIP}^2" 2>/dev/null || true)
+            if [ "$NEW_TREE" = "$OLD_TREE" ] && [ "$ALREADY_PARENT" = "$INSTRUCTOR_HEAD" ]; then
               echo "No changes to sync"
               exit 0
             fi


### PR DESCRIPTION
## Summary
- The previous no-change check only compared file trees, so it skipped when the tree was identical but the commit needed restructuring (orphan -> merge commit)
- Now also verifies that instructor HEAD is already a parent of main before skipping
- This will trigger the merge-commit rebuild on the first run, fixing the 63-ahead/1-behind issue

## Test plan
- [ ] After merge, workflow creates a merge commit on main with instructor HEAD as parent
- [ ] `git rev-list --left-right --count origin/instructor...origin/main` shows `0 1`
- [ ] GitHub shows instructor as 0 ahead, 0 behind main

🤖 Generated with [Claude Code](https://claude.com/claude-code)