### PR TITLE
fix: correct lesson 3 topology, template, and exercise errors

### DIFF
--- a/lessons/clab/03-routing-basics/ansible/templates/srl_interfaces.json.j2
+++ b/lessons/clab/03-routing-basics/ansible/templates/srl_interfaces.json.j2
@@ -15,7 +15,7 @@
 {% for iface in interfaces %}
       "set / interface {{ iface.name }} admin-state enable",
       "set / interface {{ iface.name }} subinterface 0 admin-state enable",
-      "set / interface {{ iface.name }} subinterface 0 description {{ iface.description }}",
+      "set / interface {{ iface.name }} subinterface 0 description '{{ iface.description }}'",
       "set / interface {{ iface.name }} subinterface 0 ipv4 admin-state enable",
       "set / interface {{ iface.name }} subinterface 0 ipv4 address {{ iface.ipv4_address }}",
       "set / network-instance default interface {{ iface.name }}.0",

--- a/lessons/clab/03-routing-basics/exercises/README.md
+++ b/lessons/clab/03-routing-basics/exercises/README.md
@@ -79,9 +79,9 @@ Complete these exercises to build your routing and troubleshooting skills.
 
 ---
 
-## Exercise 3: Break/Fix -- Missing Route (Asymmetric Routing)
+## Exercise 3: Break/Fix -- Missing Route
 
-**Objective:** Understand what happens when a router is missing a route and observe asymmetric routing behavior.
+**Objective:** Understand what happens when a router is missing a route and why both directions can break even when only one router is affected.
 
 ### Setup (break it)
 
@@ -104,8 +104,11 @@ exit
 # This FAILS -- host2 cannot reach host3
 docker exec clab-routing-basics-host2 ping -c 3 -W 5 10.1.5.2
 
-# But this WORKS -- host3 can reach host2
+# This ALSO FAILS -- host3 cannot reach host2 (why?)
 docker exec clab-routing-basics-host3 ping -c 3 -W 5 10.1.4.2
+
+# But this WORKS -- host1 can still reach host3
+docker exec clab-routing-basics-host1 ping -c 3 10.1.5.2
 ```
 
 ### Your Task
@@ -115,7 +118,7 @@ docker exec clab-routing-basics-host3 ping -c 3 -W 5 10.1.4.2
    docker exec -it clab-routing-basics-srl2 sr_cli -c "show network-instance default route-table ipv4-unicast summary"
    ```
 
-2. Explain why host2->host3 fails but host3->host2 works (hint: trace both directions).
+2. Explain why both host2->host3 AND host3->host2 fail, even though only srl2 is missing a route (hint: trace both the forward path and the return path for each ping).
 
 3. Fix by re-adding the route:
    ```bash
@@ -139,7 +142,7 @@ docker exec clab-routing-basics-host3 ping -c 3 -W 5 10.1.4.2
 
 ### Deliverables
 
-- Explanation of asymmetric routing (forward path vs return path)
+- Explanation of why the missing route breaks both directions (forward path vs return path)
 - The diagnostic commands you used
 
 ---
@@ -351,7 +354,7 @@ pytest tests/ -v
 
 - [ ] Exercise 1: Deployed lab, applied Ansible config, verified end-to-end connectivity
 - [ ] Exercise 2: Read routing tables, traced packet path hop by hop
-- [ ] Exercise 3: Diagnosed and fixed missing route (asymmetric routing)
+- [ ] Exercise 3: Diagnosed and fixed missing route (return path analysis)
 - [ ] Exercise 4: Diagnosed and fixed wrong next-hop (black hole)
 - [ ] Exercise 5: Diagnosed and fixed routing loop (TTL)
 - [ ] Exercise 6: Diagnosed and fixed unreachable next-hop (link down)

--- a/lessons/clab/03-routing-basics/solutions/README.md
+++ b/lessons/clab/03-routing-basics/solutions/README.md
@@ -148,7 +148,7 @@ The return path mirrors the forward path through the hub. Every hop makes an ind
 
 ---
 
-## Exercise 3: Break/Fix -- Missing Route
+## Exercise 3: Break/Fix -- Missing Route (Return Path Analysis)
 
 **srl2's routing table after deleting the route:**
 

--- a/lessons/clab/03-routing-basics/topology/lab.clab.yml
+++ b/lessons/clab/03-routing-basics/topology/lab.clab.yml
@@ -29,6 +29,7 @@ topology:
         - apk add --no-cache iputils traceroute
         - ip link set eth1 up
         - ip addr add 10.1.1.2/24 dev eth1
+        - ip route delete default
         - ip route add default via 10.1.1.1 dev eth1
 
     host2:
@@ -38,6 +39,7 @@ topology:
         - apk add --no-cache iputils traceroute
         - ip link set eth1 up
         - ip addr add 10.1.4.2/24 dev eth1
+        - ip route delete default
         - ip route add default via 10.1.4.1 dev eth1
 
     host3:
@@ -47,6 +49,7 @@ topology:
         - apk add --no-cache iputils traceroute
         - ip link set eth1 up
         - ip addr add 10.1.5.2/24 dev eth1
+        - ip route delete default
         - ip route add default via 10.1.5.1 dev eth1
 
   links:


### PR DESCRIPTION
## Summary
- Add `ip route delete default` before adding new default route in host containers (fixes deploy failure)
- Quote description values in `srl_interfaces.json.j2` so SR Linux accepts multi-word strings
- Fix Exercise 3 symptom section: both directions fail when srl2 is missing the route, not just one
- Update exercise objective, deliverables, and checklist to match corrected behavior

## Test plan
- [x] Topology deployed successfully with `ip route delete default` fix
- [x] Ansible playbook applies with quoted descriptions
- [x] Exercise 3 symptom section matches actual routing behavior
- [x] Solutions already had correct explanation -- verified consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)