### PR TITLE
fix(lesson-04): strip static routes from base configs

### DIFF
--- a/lessons/clab/04-dynamic-routing-bgp/script.md
+++ b/lessons/clab/04-dynamic-routing-bgp/script.md
@@ -122,13 +122,22 @@
 
 > "YANG paths are like filesystem paths. To reach the BGP config, the path is `/network-instance[name=default]/protocols/bgp`. To reach a specific neighbor: `/network-instance[name=default]/protocols/bgp/neighbor`. Each path targets a specific element in the device's configuration tree.
 >
+> **[VOICEOVER]**
+>
+> "Here's our topology. Same hub-and-spoke from lesson 3 -- srl1 is the hub, srl2 and srl3 are spokes, each with a host behind them. But this time, the startup configs only have interfaces. No static routes. Let's deploy."
+
+```bash
+cd lessons/clab/04-dynamic-routing-bgp
+containerlab deploy -t topology/lab.clab.yml
+```
+
 > Let me show you a quick read operation."
 
 ```bash
 # Read the system name from srl1
 gnmic -a clab-dynamic-routing-bgp-srl1:57400 -u admin -p NokiaSrl1! \
   --skip-verify -e json_ietf \
-  get --path /system/name --type config
+  get --path /system/name
 ```
 
 > "That's gNMIc reading structured data. No CLI parsing, no regex, no screen scraping. Just clean JSON in and out."
@@ -140,15 +149,6 @@ gnmic -a clab-dynamic-routing-bgp-srl1:57400 -u admin -p NokiaSrl1! \
 ---
 
 ### Section 4: Live Demo -- Static to Dynamic (3 minutes)
-
-> **[VOICEOVER]**
->
-> "Here's our topology. Same hub-and-spoke from lesson 3 -- srl1 is the hub, srl2 and srl3 are spokes, each with a host behind them. But this time, the startup configs only have interfaces. No static routes. Let's deploy."
-
-```bash
-cd lessons/clab/04-dynamic-routing-bgp
-containerlab deploy -t topology/lab.clab.yml
-```
 
 **Expected output:** Table showing 6 running containers
 

--- a/lessons/clab/04-dynamic-routing-bgp/topology/configs/srl1-base.cli
+++ b/lessons/clab/04-dynamic-routing-bgp/topology/configs/srl1-base.cli
@@ -26,14 +26,3 @@ set / interface ethernet-1/3 subinterface 0 description 'Link to srl3'
 set / interface ethernet-1/3 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/3 subinterface 0 ipv4 address 10.1.3.1/24
 set / network-instance default interface ethernet-1/3.0
-
-# --- static routes (lesson 03 baseline) ---
-set / network-instance default next-hop-groups group nhg-10-1-4-0-24 admin-state enable
-set / network-instance default next-hop-groups group nhg-10-1-4-0-24 nexthop 1 ip-address 10.1.2.2
-set / network-instance default static-routes route 10.1.4.0/24 admin-state enable
-set / network-instance default static-routes route 10.1.4.0/24 next-hop-group nhg-10-1-4-0-24
-
-set / network-instance default next-hop-groups group nhg-10-1-5-0-24 admin-state enable
-set / network-instance default next-hop-groups group nhg-10-1-5-0-24 nexthop 1 ip-address 10.1.3.2
-set / network-instance default static-routes route 10.1.5.0/24 admin-state enable
-set / network-instance default static-routes route 10.1.5.0/24 next-hop-group nhg-10-1-5-0-24

--- a/lessons/clab/04-dynamic-routing-bgp/topology/configs/srl2-base.cli
+++ b/lessons/clab/04-dynamic-routing-bgp/topology/configs/srl2-base.cli
@@ -21,19 +21,3 @@ set / interface ethernet-1/2 subinterface 0 description 'Link to host2'
 set / interface ethernet-1/2 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/2 subinterface 0 ipv4 address 10.1.4.1/24
 set / network-instance default interface ethernet-1/2.0
-
-# --- static routes (lesson 03 baseline) ---
-set / network-instance default next-hop-groups group nhg-10-1-1-0-24 admin-state enable
-set / network-instance default next-hop-groups group nhg-10-1-1-0-24 nexthop 1 ip-address 10.1.2.1
-set / network-instance default static-routes route 10.1.1.0/24 admin-state enable
-set / network-instance default static-routes route 10.1.1.0/24 next-hop-group nhg-10-1-1-0-24
-
-set / network-instance default next-hop-groups group nhg-10-1-3-0-24 admin-state enable
-set / network-instance default next-hop-groups group nhg-10-1-3-0-24 nexthop 1 ip-address 10.1.2.1
-set / network-instance default static-routes route 10.1.3.0/24 admin-state enable
-set / network-instance default static-routes route 10.1.3.0/24 next-hop-group nhg-10-1-3-0-24
-
-set / network-instance default next-hop-groups group nhg-10-1-5-0-24 admin-state enable
-set / network-instance default next-hop-groups group nhg-10-1-5-0-24 nexthop 1 ip-address 10.1.2.1
-set / network-instance default static-routes route 10.1.5.0/24 admin-state enable
-set / network-instance default static-routes route 10.1.5.0/24 next-hop-group nhg-10-1-5-0-24

--- a/lessons/clab/04-dynamic-routing-bgp/topology/configs/srl3-base.cli
+++ b/lessons/clab/04-dynamic-routing-bgp/topology/configs/srl3-base.cli
@@ -21,19 +21,3 @@ set / interface ethernet-1/2 subinterface 0 description 'Link to host3'
 set / interface ethernet-1/2 subinterface 0 ipv4 admin-state enable
 set / interface ethernet-1/2 subinterface 0 ipv4 address 10.1.5.1/24
 set / network-instance default interface ethernet-1/2.0
-
-# --- static routes (lesson 03 baseline) ---
-set / network-instance default next-hop-groups group nhg-10-1-1-0-24 admin-state enable
-set / network-instance default next-hop-groups group nhg-10-1-1-0-24 nexthop 1 ip-address 10.1.3.1
-set / network-instance default static-routes route 10.1.1.0/24 admin-state enable
-set / network-instance default static-routes route 10.1.1.0/24 next-hop-group nhg-10-1-1-0-24
-
-set / network-instance default next-hop-groups group nhg-10-1-2-0-24 admin-state enable
-set / network-instance default next-hop-groups group nhg-10-1-2-0-24 nexthop 1 ip-address 10.1.3.1
-set / network-instance default static-routes route 10.1.2.0/24 admin-state enable
-set / network-instance default static-routes route 10.1.2.0/24 next-hop-group nhg-10-1-2-0-24
-
-set / network-instance default next-hop-groups group nhg-10-1-4-0-24 admin-state enable
-set / network-instance default next-hop-groups group nhg-10-1-4-0-24 nexthop 1 ip-address 10.1.3.1
-set / network-instance default static-routes route 10.1.4.0/24 admin-state enable
-set / network-instance default static-routes route 10.1.4.0/24 next-hop-group nhg-10-1-4-0-24


### PR DESCRIPTION
## Summary
- Remove lesson-03 static routes from srl1/2/3 base configs so students start with interfaces only
- Move topology deploy earlier in the video script (before gNMIc demo)
- Drop `--type config` from gNMIc get example

## Lesson(s) Affected
- 04-dynamic-routing-bgp

## Test plan
- [ ] Topology deploys with interface-only configs
- [ ] Cross-subnet ping fails before BGP is configured
- [ ] Video script flow reads correctly with reordered sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)