### PR TITLE
fix(lesson-04): use gnmic --request-file format

### DIFF
--- a/lessons/clab/04-dynamic-routing-bgp/README.md
+++ b/lessons/clab/04-dynamic-routing-bgp/README.md
@@ -70,7 +70,7 @@ In Lessons 2-3, we used Ansible with JSON-RPC to configure routers. gNMIc takes 
 /interface[name=ethernet-1/1]/subinterface[index=0]/ipv4/admin-state
 ```
 
-gNMIc uses `set --update-file` to push JSON payloads targeting these paths. The payloads in `gnmic/configs/` contain the exact BGP configuration for each router.
+gNMIc uses `set --request-file` to push JSON payloads targeting these paths. The payloads in `gnmic/configs/` contain the exact BGP configuration for each router.
 
 ### 4. Live Demo -- Static to Dynamic (3 min)
 
@@ -82,9 +82,9 @@ cd lessons/clab/04-dynamic-routing-bgp
 containerlab deploy -t topology/lab.clab.yml
 
 # Apply BGP configuration to all three routers via gNMIc
-gnmic -a clab-dynamic-routing-bgp-srl1:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/srl1-bgp.json
-gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/srl2-bgp.json
-gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/srl3-bgp.json
+gnmic -a clab-dynamic-routing-bgp-srl1:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --request-file gnmic/configs/srl1-bgp.json
+gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --request-file gnmic/configs/srl2-bgp.json
+gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --request-file gnmic/configs/srl3-bgp.json
 ```
 
 Verify BGP sessions are Established:
@@ -107,12 +107,12 @@ Traffic between host2 and host3 currently takes the long path through the hub (s
 
 ```bash
 # Configure the new srl2-srl3 link
-gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/srl2-new-link.json
-gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/srl3-new-link.json
+gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --request-file gnmic/configs/srl2-new-link.json
+gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --request-file gnmic/configs/srl3-new-link.json
 
 # Add BGP peering between srl2 and srl3
-gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/srl2-bgp-srl3.json
-gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/srl3-bgp-srl2.json
+gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --request-file gnmic/configs/srl2-bgp-srl3.json
+gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --request-file gnmic/configs/srl3-bgp-srl2.json
 ```
 
 Now traceroute shows the direct path:
@@ -215,7 +215,7 @@ If you run Kubernetes with Calico CNI, every node is a BGP speaker advertising i
 |---------|---------|
 | `containerlab deploy -t topology/lab.clab.yml` | Deploy the lab |
 | `containerlab destroy -t topology/lab.clab.yml --cleanup` | Destroy the lab |
-| `gnmic -a HOST:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file FILE` | Apply config via gNMIc |
+| `gnmic -a HOST:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --request-file FILE` | Apply config via gNMIc |
 | `gnmic -a HOST:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf get --path PATH --type state` | Read state via gNMIc |
 | `gnmic -a HOST:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --delete PATH` | Delete config via gNMIc |
 | `docker exec -it clab-dynamic-routing-bgp-srl1 sr_cli` | Connect to srl1 CLI |

--- a/lessons/clab/04-dynamic-routing-bgp/exercises/README.md
+++ b/lessons/clab/04-dynamic-routing-bgp/exercises/README.md
@@ -39,11 +39,11 @@ Complete these exercises to understand how BGP replaces static routes with dynam
    ```bash
    cd gnmic
    gnmic -a clab-dynamic-routing-bgp-srl1:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/srl1-bgp.json
+     --skip-verify -e json_ietf set --request-file configs/srl1-bgp.json
    gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/srl2-bgp.json
+     --skip-verify -e json_ietf set --request-file configs/srl2-bgp.json
    gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/srl3-bgp.json
+     --skip-verify -e json_ietf set --request-file configs/srl3-bgp.json
    ```
 
 7. Verify BGP sessions are established:
@@ -85,17 +85,17 @@ Complete these exercises to understand how BGP replaces static routes with dynam
 2. Configure the srl2-srl3 interfaces:
    ```bash
    gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/srl2-new-link.json
+     --skip-verify -e json_ietf set --request-file configs/srl2-new-link.json
    gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/srl3-new-link.json
+     --skip-verify -e json_ietf set --request-file configs/srl3-new-link.json
    ```
 
 3. Add BGP neighbors for the new link:
    ```bash
    gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/srl2-bgp-srl3.json
+     --skip-verify -e json_ietf set --request-file configs/srl2-bgp-srl3.json
    gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/srl3-bgp-srl2.json
+     --skip-verify -e json_ietf set --request-file configs/srl3-bgp-srl2.json
    ```
 
 4. Verify the new BGP session is established:

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl1-bgp.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl1-bgp.json
@@ -1,44 +1,48 @@
-[
-  {
-    "path": "/routing-policy/policy[name=export-connected]",
-    "value": {
-      "default-action": {"policy-result": "reject"},
-      "statement": [
-        {
-          "name": "10",
-          "match": {"protocol": "local"},
-          "action": {"policy-result": "accept"}
-        }
-      ]
+{
+  "updates": [
+    {
+      "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": {"policy-result": "reject"},
+        "statement": [
+          {
+            "name": "10",
+            "match": {"protocol": "local"},
+            "action": {"policy-result": "accept"}
+          }
+        ]
+      },
+      "encoding": "json_ietf"
+    },
+    {
+      "path": "/network-instance[name=default]/protocols/bgp",
+      "value": {
+        "admin-state": "enable",
+        "autonomous-system": 65001,
+        "router-id": "10.0.0.1",
+        "group": [
+          {
+            "group-name": "ebgp-peers",
+            "admin-state": "enable",
+            "export-policy": "export-connected"
+          }
+        ],
+        "neighbor": [
+          {
+            "peer-address": "10.1.2.2",
+            "admin-state": "enable",
+            "peer-as": 65002,
+            "peer-group": "ebgp-peers"
+          },
+          {
+            "peer-address": "10.1.3.2",
+            "admin-state": "enable",
+            "peer-as": 65003,
+            "peer-group": "ebgp-peers"
+          }
+        ]
+      },
+      "encoding": "json_ietf"
     }
-  },
-  {
-    "path": "/network-instance[name=default]/protocols/bgp",
-    "value": {
-      "admin-state": "enable",
-      "autonomous-system": 65001,
-      "router-id": "10.0.0.1",
-      "group": [
-        {
-          "group-name": "ebgp-peers",
-          "admin-state": "enable",
-          "export-policy": "export-connected"
-        }
-      ],
-      "neighbor": [
-        {
-          "peer-address": "10.1.2.2",
-          "admin-state": "enable",
-          "peer-as": 65002,
-          "peer-group": "ebgp-peers"
-        },
-        {
-          "peer-address": "10.1.3.2",
-          "admin-state": "enable",
-          "peer-as": 65003,
-          "peer-group": "ebgp-peers"
-        }
-      ]
-    }
-  }
-]
+  ]
+}

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl2-bgp-srl3.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl2-bgp-srl3.json
@@ -1,10 +1,13 @@
-[
-  {
-    "path": "/network-instance[name=default]/protocols/bgp/neighbor[peer-address=10.1.6.2]",
-    "value": {
-      "admin-state": "enable",
-      "peer-as": 65003,
-      "peer-group": "ebgp-peers"
+{
+  "updates": [
+    {
+      "path": "/network-instance[name=default]/protocols/bgp/neighbor[peer-address=10.1.6.2]",
+      "value": {
+        "admin-state": "enable",
+        "peer-as": 65003,
+        "peer-group": "ebgp-peers"
+      },
+      "encoding": "json_ietf"
     }
-  }
-]
+  ]
+}

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl2-bgp.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl2-bgp.json
@@ -1,38 +1,42 @@
-[
-  {
-    "path": "/routing-policy/policy[name=export-connected]",
-    "value": {
-      "default-action": {"policy-result": "reject"},
-      "statement": [
-        {
-          "name": "10",
-          "match": {"protocol": "local"},
-          "action": {"policy-result": "accept"}
-        }
-      ]
+{
+  "updates": [
+    {
+      "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": {"policy-result": "reject"},
+        "statement": [
+          {
+            "name": "10",
+            "match": {"protocol": "local"},
+            "action": {"policy-result": "accept"}
+          }
+        ]
+      },
+      "encoding": "json_ietf"
+    },
+    {
+      "path": "/network-instance[name=default]/protocols/bgp",
+      "value": {
+        "admin-state": "enable",
+        "autonomous-system": 65002,
+        "router-id": "10.0.0.2",
+        "group": [
+          {
+            "group-name": "ebgp-peers",
+            "admin-state": "enable",
+            "export-policy": "export-connected"
+          }
+        ],
+        "neighbor": [
+          {
+            "peer-address": "10.1.2.1",
+            "admin-state": "enable",
+            "peer-as": 65001,
+            "peer-group": "ebgp-peers"
+          }
+        ]
+      },
+      "encoding": "json_ietf"
     }
-  },
-  {
-    "path": "/network-instance[name=default]/protocols/bgp",
-    "value": {
-      "admin-state": "enable",
-      "autonomous-system": 65002,
-      "router-id": "10.0.0.2",
-      "group": [
-        {
-          "group-name": "ebgp-peers",
-          "admin-state": "enable",
-          "export-policy": "export-connected"
-        }
-      ],
-      "neighbor": [
-        {
-          "peer-address": "10.1.2.1",
-          "admin-state": "enable",
-          "peer-as": 65001,
-          "peer-group": "ebgp-peers"
-        }
-      ]
-    }
-  }
-]
+  ]
+}

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl2-new-link.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl2-new-link.json
@@ -1,23 +1,27 @@
-[
-  {
-    "path": "/interface[name=ethernet-1/3]",
-    "value": {
-      "admin-state": "enable",
-      "subinterface": [
-        {
-          "index": 0,
-          "admin-state": "enable",
-          "description": "Link to srl3",
-          "ipv4": {
+{
+  "updates": [
+    {
+      "path": "/interface[name=ethernet-1/3]",
+      "value": {
+        "admin-state": "enable",
+        "subinterface": [
+          {
+            "index": 0,
             "admin-state": "enable",
-            "address": [{"ip-prefix": "10.1.6.1/24"}]
+            "description": "Link to srl3",
+            "ipv4": {
+              "admin-state": "enable",
+              "address": [{"ip-prefix": "10.1.6.1/24"}]
+            }
           }
-        }
-      ]
+        ]
+      },
+      "encoding": "json_ietf"
+    },
+    {
+      "path": "/network-instance[name=default]/interface[name=ethernet-1/3.0]",
+      "value": {},
+      "encoding": "json_ietf"
     }
-  },
-  {
-    "path": "/network-instance[name=default]/interface[name=ethernet-1/3.0]",
-    "value": {}
-  }
-]
+  ]
+}

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl3-bgp-srl2.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl3-bgp-srl2.json
@@ -1,10 +1,13 @@
-[
-  {
-    "path": "/network-instance[name=default]/protocols/bgp/neighbor[peer-address=10.1.6.1]",
-    "value": {
-      "admin-state": "enable",
-      "peer-as": 65002,
-      "peer-group": "ebgp-peers"
+{
+  "updates": [
+    {
+      "path": "/network-instance[name=default]/protocols/bgp/neighbor[peer-address=10.1.6.1]",
+      "value": {
+        "admin-state": "enable",
+        "peer-as": 65002,
+        "peer-group": "ebgp-peers"
+      },
+      "encoding": "json_ietf"
     }
-  }
-]
+  ]
+}

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl3-bgp.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl3-bgp.json
@@ -1,38 +1,42 @@
-[
-  {
-    "path": "/routing-policy/policy[name=export-connected]",
-    "value": {
-      "default-action": {"policy-result": "reject"},
-      "statement": [
-        {
-          "name": "10",
-          "match": {"protocol": "local"},
-          "action": {"policy-result": "accept"}
-        }
-      ]
+{
+  "updates": [
+    {
+      "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": {"policy-result": "reject"},
+        "statement": [
+          {
+            "name": "10",
+            "match": {"protocol": "local"},
+            "action": {"policy-result": "accept"}
+          }
+        ]
+      },
+      "encoding": "json_ietf"
+    },
+    {
+      "path": "/network-instance[name=default]/protocols/bgp",
+      "value": {
+        "admin-state": "enable",
+        "autonomous-system": 65003,
+        "router-id": "10.0.0.3",
+        "group": [
+          {
+            "group-name": "ebgp-peers",
+            "admin-state": "enable",
+            "export-policy": "export-connected"
+          }
+        ],
+        "neighbor": [
+          {
+            "peer-address": "10.1.3.1",
+            "admin-state": "enable",
+            "peer-as": 65001,
+            "peer-group": "ebgp-peers"
+          }
+        ]
+      },
+      "encoding": "json_ietf"
     }
-  },
-  {
-    "path": "/network-instance[name=default]/protocols/bgp",
-    "value": {
-      "admin-state": "enable",
-      "autonomous-system": 65003,
-      "router-id": "10.0.0.3",
-      "group": [
-        {
-          "group-name": "ebgp-peers",
-          "admin-state": "enable",
-          "export-policy": "export-connected"
-        }
-      ],
-      "neighbor": [
-        {
-          "peer-address": "10.1.3.1",
-          "admin-state": "enable",
-          "peer-as": 65001,
-          "peer-group": "ebgp-peers"
-        }
-      ]
-    }
-  }
-]
+  ]
+}

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl3-new-link.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl3-new-link.json
@@ -1,23 +1,27 @@
-[
-  {
-    "path": "/interface[name=ethernet-1/3]",
-    "value": {
-      "admin-state": "enable",
-      "subinterface": [
-        {
-          "index": 0,
-          "admin-state": "enable",
-          "description": "Link to srl2",
-          "ipv4": {
+{
+  "updates": [
+    {
+      "path": "/interface[name=ethernet-1/3]",
+      "value": {
+        "admin-state": "enable",
+        "subinterface": [
+          {
+            "index": 0,
             "admin-state": "enable",
-            "address": [{"ip-prefix": "10.1.6.2/24"}]
+            "description": "Link to srl2",
+            "ipv4": {
+              "admin-state": "enable",
+              "address": [{"ip-prefix": "10.1.6.2/24"}]
+            }
           }
-        }
-      ]
+        ]
+      },
+      "encoding": "json_ietf"
+    },
+    {
+      "path": "/network-instance[name=default]/interface[name=ethernet-1/3.0]",
+      "value": {},
+      "encoding": "json_ietf"
     }
-  },
-  {
-    "path": "/network-instance[name=default]/interface[name=ethernet-1/3.0]",
-    "value": {}
-  }
-]
+  ]
+}

--- a/lessons/clab/04-dynamic-routing-bgp/script.md
+++ b/lessons/clab/04-dynamic-routing-bgp/script.md
@@ -163,13 +163,13 @@ docker exec clab-dynamic-routing-bgp-host1 ping -c 2 10.1.4.2
 ```bash
 # Apply BGP config to all three routers
 gnmic -a clab-dynamic-routing-bgp-srl1:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file gnmic/configs/srl1-bgp.json
+  --skip-verify -e json_ietf set --request-file gnmic/configs/srl1-bgp.json
 
 gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file gnmic/configs/srl2-bgp.json
+  --skip-verify -e json_ietf set --request-file gnmic/configs/srl2-bgp.json
 
 gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file gnmic/configs/srl3-bgp.json
+  --skip-verify -e json_ietf set --request-file gnmic/configs/srl3-bgp.json
 ```
 
 > "Three commands, three routers configured. Each payload creates the export policy, the peer-group, and the BGP neighbors. Let's check the sessions."
@@ -215,17 +215,17 @@ docker exec clab-dynamic-routing-bgp-host2 traceroute 10.1.5.2
 ```bash
 # Configure interfaces on the new link
 gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file gnmic/configs/srl2-new-link.json
+  --skip-verify -e json_ietf set --request-file gnmic/configs/srl2-new-link.json
 
 gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file gnmic/configs/srl3-new-link.json
+  --skip-verify -e json_ietf set --request-file gnmic/configs/srl3-new-link.json
 
 # Add BGP peering between srl2 and srl3
 gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file gnmic/configs/srl2-bgp-srl3.json
+  --skip-verify -e json_ietf set --request-file gnmic/configs/srl2-bgp-srl3.json
 
 gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file gnmic/configs/srl3-bgp-srl2.json
+  --skip-verify -e json_ietf set --request-file gnmic/configs/srl3-bgp-srl2.json
 ```
 
 > "Four commands: two to bring up the interfaces with IP addresses, two to establish the BGP peering. Let's check the session."

--- a/lessons/clab/04-dynamic-routing-bgp/solutions/README.md
+++ b/lessons/clab/04-dynamic-routing-bgp/solutions/README.md
@@ -57,7 +57,7 @@ ethernet-1/3 is physically up (the cable is wired in the topology) but has no su
 
 ```bash
 $ gnmic -a clab-dynamic-routing-bgp-srl1:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/srl1-bgp.json
+    --skip-verify -e json_ietf set --request-file configs/srl1-bgp.json
 {
   "time": "2026-03-15T12:01:15Z",
   "results": [
@@ -152,7 +152,7 @@ The path is host2 -> srl2 (10.1.4.1) -> srl1 (10.1.2.1) -> srl3 (10.1.3.2) -> ho
 
 ```bash
 $ gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/srl2-new-link.json
+    --skip-verify -e json_ietf set --request-file configs/srl2-new-link.json
 {
   "time": "2026-03-15T12:05:00Z",
   "results": [
@@ -168,7 +168,7 @@ $ gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! \
 }
 
 $ gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/srl3-new-link.json
+    --skip-verify -e json_ietf set --request-file configs/srl3-new-link.json
 {
   "time": "2026-03-15T12:05:05Z",
   "results": [
@@ -188,7 +188,7 @@ $ gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! \
 
 ```bash
 $ gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/srl2-bgp-srl3.json
+    --skip-verify -e json_ietf set --request-file configs/srl2-bgp-srl3.json
 {
   "time": "2026-03-15T12:05:30Z",
   "results": [
@@ -200,7 +200,7 @@ $ gnmic -a clab-dynamic-routing-bgp-srl2:57400 -u admin -p NokiaSrl1! \
 }
 
 $ gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/srl3-bgp-srl2.json
+    --skip-verify -e json_ietf set --request-file configs/srl3-bgp-srl2.json
 {
   "time": "2026-03-15T12:05:35Z",
   "results": [


### PR DESCRIPTION
## Summary
- Wrap all gnmic JSON config files in the `SetRequestFile` envelope format (`{"updates": [...]}`) so `--request-file` can parse them
- Replace `--update-file` with `--request-file` in all commands across README, exercises, solutions, and video script

## Lesson(s) Affected
- 04-dynamic-routing-bgp

## Test plan
- [x] Verified `gnmic set --request-file` accepts the new JSON format against a running lab
- [x] Grep confirms zero remaining `--update-file` references in lesson 04

🤖 Generated with [Claude Code](https://claude.com/claude-code)