### PR TITLE
fix(lesson-04): fix gnmic BGP configs for SR Linux YANG compliance

### DIFF
--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl1-bgp.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl1-bgp.json
@@ -20,11 +20,17 @@
         "admin-state": "enable",
         "autonomous-system": 65001,
         "router-id": "10.0.0.1",
+        "afi-safi": [
+          {
+            "afi-safi-name": "ipv4-unicast",
+            "admin-state": "enable"
+          }
+        ],
         "group": [
           {
             "group-name": "ebgp-peers",
             "admin-state": "enable",
-            "export-policy": "export-connected"
+            "export-policy": ["export-connected"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl2-bgp.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl2-bgp.json
@@ -20,11 +20,17 @@
         "admin-state": "enable",
         "autonomous-system": 65002,
         "router-id": "10.0.0.2",
+        "afi-safi": [
+          {
+            "afi-safi-name": "ipv4-unicast",
+            "admin-state": "enable"
+          }
+        ],
         "group": [
           {
             "group-name": "ebgp-peers",
             "admin-state": "enable",
-            "export-policy": "export-connected"
+            "export-policy": ["export-connected"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl3-bgp.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl3-bgp.json
@@ -20,11 +20,17 @@
         "admin-state": "enable",
         "autonomous-system": 65003,
         "router-id": "10.0.0.3",
+        "afi-safi": [
+          {
+            "afi-safi-name": "ipv4-unicast",
+            "admin-state": "enable"
+          }
+        ],
         "group": [
           {
             "group-name": "ebgp-peers",
             "admin-state": "enable",
-            "export-policy": "export-connected"
+            "export-policy": ["export-connected"]
           }
         ],
         "neighbor": [


### PR DESCRIPTION
## Summary
- Fix `export-policy` to use leaf-list array syntax (`["export-connected"]` not `"export-connected"`)
- Add explicit `ipv4-unicast` afi-safi enablement required by gNMI (CLI auto-enables, gNMI does not)

## Lesson(s) Affected
- 04-dynamic-routing-bgp

## Test plan
- [x] Verified `gnmic set --request-file` succeeds on all three routers
- [x] BGP sessions reach Established state
- [x] Verified break/fix exercises (3-6) unaffected — all use CLI, not gnmic

🤖 Generated with [Claude Code](https://claude.com/claude-code)