### PR TITLE
feat(lesson-04): add policy chaining, import policy, and BGP best path

### DIFF
--- a/lessons/clab/04-dynamic-routing-bgp/README.md
+++ b/lessons/clab/04-dynamic-routing-bgp/README.md
@@ -50,7 +50,37 @@ BGP (Border Gateway Protocol) is the routing protocol that runs the internet. In
 | OpenConfirm | OPEN received, waiting for KEEPALIVE |
 | Established | Peers are up, exchanging routes |
 
-**Export Policy (SR Linux default-deny):** SR Linux does not advertise any routes by default. You must create an explicit export policy that matches the routes you want to share. Without this, sessions come up but no routes are exchanged -- the most common BGP debugging trap on SR Linux.
+**Routing Policies (SR Linux default-deny):** SR Linux does not accept or advertise any BGP routes by default. You must create explicit policies:
+
+- **Import policy:** Controls which received routes are accepted into the routing table. Without one, received routes are rejected.
+- **Export policy:** Controls which routes are advertised to peers. Without one, no routes are shared.
+
+In this lab, we use three policies chained together:
+
+| Policy | Purpose | Default Action |
+|--------|---------|----------------|
+| `import-all` | Accept all received routes | accept |
+| `export-connected` | Advertise directly connected subnets | next-policy |
+| `export-bgp` | Re-advertise BGP-learned routes | reject |
+
+**Policy chaining:** When a peer-group has multiple export policies (`[export-connected, export-bgp]`), SR Linux evaluates them in order. If a route matches a statement with `accept`, it's advertised. If it doesn't match any statement and the default-action is `next-policy`, it passes to the next policy in the chain. If the default-action is `reject`, the route is dropped. This lets you build modular, composable policies instead of one monolithic rule set.
+
+### BGP Best Path Algorithm
+
+When a router receives the same prefix from multiple peers, BGP uses a decision process to select the best path. The simplified algorithm (in order of priority):
+
+| Step | Attribute | Rule | In This Lab |
+|------|-----------|------|-------------|
+| 1 | Local Preference | Highest wins | Not set (default 100) |
+| 2 | AS Path Length | Shortest wins | Exercise 2 demonstrates this |
+| 3 | Origin | IGP (i) > EGP (e) > incomplete (?) | All routes are IGP |
+| 4 | MED | Lowest wins (from same neighbor AS) | Not set |
+| 5 | eBGP vs iBGP | eBGP preferred | All peers are eBGP |
+| 6 | Router ID | Lowest wins (tiebreaker) | Only used if everything else ties |
+
+In Exercise 2, when srl2 receives 10.1.5.0/24 from both srl1 (AS path: [65001, 65003]) and srl3 (AS path: [65003]), steps 1, 3, 4, and 5 are equal. Step 2 breaks the tie -- the direct path through srl3 has a shorter AS path (1 hop vs 2 hops), so BGP selects it automatically.
+
+You can see these attributes in the output of `show network-instance default protocols bgp routes ipv4 prefix <prefix> detail`. The `MED is -, No LocalPref` line means those attributes are at their defaults and not influencing the decision.
 
 ### 3. Introducing gNMIc (2 min)
 

--- a/lessons/clab/04-dynamic-routing-bgp/exercises/README.md
+++ b/lessons/clab/04-dynamic-routing-bgp/exercises/README.md
@@ -114,12 +114,19 @@ Complete these exercises to understand how BGP replaces static routes with dynam
    docker exec -it clab-dynamic-routing-bgp-srl2 sr_cli -c "show network-instance default protocols bgp routes ipv4 summary"
    ```
 
+7. Inspect the best path detail for host3's subnet to see why BGP chose the direct path:
+   ```bash
+   docker exec -it clab-dynamic-routing-bgp-srl2 sr_cli -c "show network-instance default protocols bgp routes ipv4 prefix 10.1.5.0/24 detail"
+   ```
+   Look at the AS path for each received path. The best path algorithm checks Local Preference first (equal), then AS Path Length (shorter wins).
+
 Note: In lesson 03, adding a cable accomplished nothing without adding static routes. With BGP, adding a cable and a peering session changes the forwarding path within seconds.
 
 ### Deliverables
 
 - Before/after traceroute output
-- Explanation of AS path selection
+- BGP route detail showing two paths with different AS path lengths
+- Explanation of which best path algorithm step decided the winner
 
 ---
 
@@ -161,14 +168,14 @@ docker exec clab-dynamic-routing-bgp-host3 ping -c 3 10.1.1.2
 
 2. Look at received vs sent route counts. srl3 receives routes (it can reach out) but sends 0 (nobody can reach it).
 
-3. Fix by re-adding the export policy:
+3. Fix by re-adding both export policies:
    ```bash
    docker exec -it clab-dynamic-routing-bgp-srl3 sr_cli
    ```
    Inside SR Linux:
    ```
    enter candidate
-   set / network-instance default protocols bgp group ebgp-peers export-policy [export-connected]
+   set / network-instance default protocols bgp group ebgp-peers export-policy [export-connected export-bgp]
    commit now
    exit
    ```

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl1-bgp.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl1-bgp.json
@@ -1,13 +1,34 @@
 {
   "updates": [
     {
+      "path": "/routing-policy/policy[name=import-all]",
+      "value": {
+        "default-action": {"policy-result": "accept"}
+      },
+      "encoding": "json_ietf"
+    },
+    {
       "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": {"policy-result": "next-policy"},
+        "statement": [
+          {
+            "name": "10",
+            "match": {"protocol": "local"},
+            "action": {"policy-result": "accept"}
+          }
+        ]
+      },
+      "encoding": "json_ietf"
+    },
+    {
+      "path": "/routing-policy/policy[name=export-bgp]",
       "value": {
         "default-action": {"policy-result": "reject"},
         "statement": [
           {
             "name": "10",
-            "match": {"protocol": "local"},
+            "match": {"protocol": "bgp"},
             "action": {"policy-result": "accept"}
           }
         ]
@@ -30,7 +51,8 @@
           {
             "group-name": "ebgp-peers",
             "admin-state": "enable",
-            "export-policy": ["export-connected"]
+            "import-policy": ["import-all"],
+            "export-policy": ["export-connected", "export-bgp"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl2-bgp.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl2-bgp.json
@@ -1,13 +1,34 @@
 {
   "updates": [
     {
+      "path": "/routing-policy/policy[name=import-all]",
+      "value": {
+        "default-action": {"policy-result": "accept"}
+      },
+      "encoding": "json_ietf"
+    },
+    {
       "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": {"policy-result": "next-policy"},
+        "statement": [
+          {
+            "name": "10",
+            "match": {"protocol": "local"},
+            "action": {"policy-result": "accept"}
+          }
+        ]
+      },
+      "encoding": "json_ietf"
+    },
+    {
+      "path": "/routing-policy/policy[name=export-bgp]",
       "value": {
         "default-action": {"policy-result": "reject"},
         "statement": [
           {
             "name": "10",
-            "match": {"protocol": "local"},
+            "match": {"protocol": "bgp"},
             "action": {"policy-result": "accept"}
           }
         ]
@@ -30,7 +51,8 @@
           {
             "group-name": "ebgp-peers",
             "admin-state": "enable",
-            "export-policy": ["export-connected"]
+            "import-policy": ["import-all"],
+            "export-policy": ["export-connected", "export-bgp"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl3-bgp.json
+++ b/lessons/clab/04-dynamic-routing-bgp/gnmic/configs/srl3-bgp.json
@@ -1,13 +1,34 @@
 {
   "updates": [
     {
+      "path": "/routing-policy/policy[name=import-all]",
+      "value": {
+        "default-action": {"policy-result": "accept"}
+      },
+      "encoding": "json_ietf"
+    },
+    {
       "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": {"policy-result": "next-policy"},
+        "statement": [
+          {
+            "name": "10",
+            "match": {"protocol": "local"},
+            "action": {"policy-result": "accept"}
+          }
+        ]
+      },
+      "encoding": "json_ietf"
+    },
+    {
+      "path": "/routing-policy/policy[name=export-bgp]",
       "value": {
         "default-action": {"policy-result": "reject"},
         "statement": [
           {
             "name": "10",
-            "match": {"protocol": "local"},
+            "match": {"protocol": "bgp"},
             "action": {"policy-result": "accept"}
           }
         ]
@@ -30,7 +51,8 @@
           {
             "group-name": "ebgp-peers",
             "admin-state": "enable",
-            "export-policy": ["export-connected"]
+            "import-policy": ["import-all"],
+            "export-policy": ["export-connected", "export-bgp"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/04-dynamic-routing-bgp/script.md
+++ b/lessons/clab/04-dynamic-routing-bgp/script.md
@@ -75,31 +75,25 @@
 >
 > Third, session states. BGP peers go through a state machine: Idle, Connect, OpenSent, OpenConfirm, Established. Established is the goal -- that means routes are flowing. If you see a session stuck in Active or Connect, something is wrong: check the IP addresses, the ASN configuration, and whether the peer is reachable.
 >
-> And here's the trap that catches everyone on SR Linux: export policy. SR Linux is secure by default -- BGP advertises nothing unless you explicitly allow it. You need a routing policy that matches the routes you want to share, and you apply that policy to your peer-group. Without it, sessions come up Established, but the routing table stays empty. Zero routes exchanged."
+> And here's the trap that catches everyone on SR Linux: routing policies. SR Linux is secure by default -- it won't accept OR advertise BGP routes unless you explicitly allow it. You need both an import policy and an export policy.
+>
+> In our lab, we use three policies. First, `import-all` -- this simply accepts all received routes. Second, `export-connected` -- this matches directly connected subnets and advertises them. Third, `export-bgp` -- this matches routes learned via BGP and re-advertises them to other peers.
+>
+> The interesting part is how these chain together. When you apply multiple export policies to a peer-group, SR Linux evaluates them in order. `export-connected` has a default-action of `next-policy` -- if a route doesn't match the 'local protocol' statement, it gets passed to the next policy instead of being rejected. `export-bgp` then checks if it's a BGP-learned route. This gives you modular, composable policies instead of one giant rule."
 
-**Visual:** BGP state machine diagram, export policy config on screen
+**Visual:** BGP state machine diagram, policy chain flow on screen
 
-```json
-{
-  "path": "/routing-policy/policy[name=export-connected]",
-  "value": {
-    "default-action": {"policy-result": "reject"},
-    "statement": [
-      {
-        "name": "10",
-        "match": {"protocol": "local"},
-        "action": {"policy-result": "accept"}
-      }
-    ]
-  }
-}
-```
+> "One more concept before we start configuring. When a router learns the same prefix from multiple peers, how does it choose? BGP has a best path algorithm. The key steps in order: highest Local Preference wins, then shortest AS Path, then lowest origin type, then lowest MED, then eBGP over iBGP, and finally lowest router ID as a tiebreaker.
+>
+> In our lab, the one that matters most is AS Path Length. When srl2 learns a route to host3's subnet from both srl1 and srl3, the direct path through srl3 has one AS hop while the path through srl1 has two. Shorter AS path wins. You'll see this in action in the exercises."
 
 **Key Points:**
 - AS = administrative domain, each router gets its own AS (eBGP)
 - Peering is explicit -- both sides must be configured
 - Session states: Idle -> Connect -> OpenSent -> OpenConfirm -> Established
-- SR Linux default-deny: must create export policy or no routes are advertised
+- SR Linux default-deny: must create import AND export policies
+- Policy chaining: `next-policy` default-action passes unmatched routes to the next policy
+- Best path algorithm: Local Pref > AS Path Length > Origin > MED > eBGP/iBGP > Router ID
 
 **Transition:** "Now let's talk about how we'll push this config to the routers."
 
@@ -172,7 +166,7 @@ gnmic -a clab-dynamic-routing-bgp-srl3:57400 -u admin -p NokiaSrl1! \
   --skip-verify -e json_ietf set --request-file gnmic/configs/srl3-bgp.json
 ```
 
-> "Three commands, three routers configured. Each payload creates the export policy, the peer-group, and the BGP neighbors. Let's check the sessions."
+> "Three commands, three routers configured. Each payload creates three routing policies -- import-all, export-connected, and export-bgp -- then enables BGP with the peer-group and neighbors. Let's check the sessions."
 
 ```bash
 docker exec -it clab-dynamic-routing-bgp-srl1 sr_cli -c \
@@ -241,7 +235,7 @@ docker exec -it clab-dynamic-routing-bgp-srl2 sr_cli -c \
 docker exec clab-dynamic-routing-bgp-host2 traceroute 10.1.5.2
 ```
 
-> "Two hops instead of three. BGP chose the shorter AS path automatically. The route through srl1 crosses two autonomous systems -- AS 65001 then AS 65003. The direct route to srl3 crosses one -- just AS 65003. BGP prefers the shorter AS path. No manual intervention required."
+> "Two hops instead of three. This is the BGP best path algorithm in action. srl2 now has two routes to host3's subnet. The old path through srl1 has an AS path of [65001, 65003] -- two hops. The new direct path has an AS path of [65003] -- one hop. Local Preference and Origin are equal, so step 2 of the algorithm breaks the tie: shortest AS path wins. No manual intervention required."
 
 **Visual:** Terminal with traceroute output, before and after comparison
 
@@ -254,9 +248,9 @@ docker exec clab-dynamic-routing-bgp-host2 traceroute 10.1.5.2
 > "Let's recap:
 >
 > - BGP replaces manual route management with automatic route exchange between routers.
-> - Export policies on SR Linux control what gets advertised -- without one, nothing is shared.
+> - SR Linux is default-deny: you need both import and export policies, and you can chain export policies using `next-policy`.
 > - gNMIc pushes structured config via gRPC -- no templates, no CLI string parsing.
-> - When the network topology changes, BGP adapts automatically. Shorter AS path wins."
+> - When the network topology changes, BGP's best path algorithm adapts automatically. In our lab, shorter AS path won -- but the algorithm checks Local Preference, Origin, MED, and more before it gets there."
 
 ---
 

--- a/lessons/clab/04-dynamic-routing-bgp/solutions/README.md
+++ b/lessons/clab/04-dynamic-routing-bgp/solutions/README.md
@@ -63,7 +63,15 @@ $ gnmic -a clab-dynamic-routing-bgp-srl1:57400 -u admin -p NokiaSrl1! \
   "results": [
     {
       "operation": "UPDATE",
+      "path": "routing-policy/policy[name=import-all]"
+    },
+    {
+      "operation": "UPDATE",
       "path": "routing-policy/policy[name=export-connected]"
+    },
+    {
+      "operation": "UPDATE",
+      "path": "routing-policy/policy[name=export-bgp]"
     },
     {
       "operation": "UPDATE",
@@ -73,7 +81,11 @@ $ gnmic -a clab-dynamic-routing-bgp-srl1:57400 -u admin -p NokiaSrl1! \
 }
 ```
 
-Repeat for srl2 and srl3 with their respective config files. Each config creates the `export-connected` routing policy and enables BGP with the appropriate AS number and neighbors.
+Repeat for srl2 and srl3 with their respective config files. Each config creates three routing policies and enables BGP:
+
+- **`import-all`** -- accepts all received routes (SR Linux default-deny requires an explicit import policy)
+- **`export-connected`** -- matches directly connected subnets (`protocol: local`) and advertises them; unmatched routes pass to the next policy via `default-action: next-policy`
+- **`export-bgp`** -- matches BGP-learned routes and re-advertises them to other peers, enabling transit routing through the hub
 
 **Step 7: BGP neighbors all Established.**
 
@@ -242,16 +254,24 @@ traceroute to 10.1.5.2 (10.1.5.2), 30 hops max, 60 byte packets
 
 The path is now host2 -> srl2 (10.1.4.1) -> srl3 (10.1.6.2) -> host3 (10.1.5.2). Two router hops -- srl1 is bypassed entirely.
 
-**Why BGP chose the direct path:** BGP path selection prefers shorter AS paths. Before the new link, srl2's only route to 10.1.5.0/24 was through srl1:
+**Why BGP chose the direct path:** BGP uses a best path algorithm to select between multiple routes to the same prefix. The algorithm evaluates attributes in strict order:
 
-- **Old path AS path:** [65001, 65003] -- the route was learned from srl1 (AS 65001), who learned it from srl3 (AS 65003). Two AS hops.
-- **New path AS path:** [65003] -- the route was learned directly from srl3 (AS 65003). One AS hop.
+| Step | Attribute | Old Path (via srl1) | New Path (via srl3) |
+|------|-----------|---------------------|---------------------|
+| 1 | Local Preference | default (100) | default (100) |
+| 2 | **AS Path Length** | **[65001, 65003] = 2 hops** | **[65003] = 1 hop** |
+| 3 | Origin | IGP (i) | IGP (i) |
+| 4 | MED | not set | not set |
+| 5 | eBGP vs iBGP | eBGP | eBGP |
+| 6 | Router ID | n/a (already decided) | n/a |
 
-BGP prefers the path with fewer AS hops, so the direct route through srl3 wins automatically. No manual route changes were needed -- BGP recalculated the best path the moment the new session came up.
+Step 1 is a tie (both use default Local Preference). Step 2 breaks it -- the direct path has a shorter AS path (1 hop vs 2 hops), so BGP selects it. Steps 3-6 are never reached.
+
+You can verify this with `show network-instance default protocols bgp routes ipv4 prefix 10.1.5.0/24 detail` on srl2. The output shows `MED is -, No LocalPref` (both at defaults) and the AS path for each received route.
 
 In lesson 03, adding a cable accomplished nothing. The physical link existed, but without manually adding static routes on both srl2 and srl3, it sat idle. With BGP, the new link was automatically discovered and traffic shifted within seconds. This is the fundamental difference between static and dynamic routing: dynamic protocols react to topology changes on their own.
 
-**Key lesson:** BGP path selection prefers shorter AS paths. Adding a direct link between two routers creates a shorter AS path that BGP automatically prefers over the longer path through the hub. No manual intervention is required.
+**Key lesson:** BGP's best path algorithm selected the direct path because it has a shorter AS path. In this lab, AS Path Length is the deciding factor because all other attributes (Local Preference, Origin, MED) are equal. In production networks, operators use Local Preference and MED to influence path selection beyond what AS path length provides.
 
 ---
 
@@ -288,7 +308,7 @@ A:srl3# show network-instance default protocols bgp neighbor 10.1.3.1 detail
 | Session state: established                                          |
 | Last state: established                                             |
 | Export policy: --                                                   |
-| Import policy: --                                                   |
+| Import policy: ['import-all']                                       |
 |                                                                     |
 | Messages:                                                           |
 |   Sent:          12    Received:      14                            |
@@ -300,15 +320,15 @@ A:srl3# show network-instance default protocols bgp neighbor 10.1.3.1 detail
 
 The critical fields: `Export policy: --` (no export policy) and `Sent: 0` (srl3 is advertising zero routes). The session is `established` -- the TCP connection and BGP OPEN/KEEPALIVE exchange are working perfectly. The problem is in the UPDATE messages: srl3 has nothing to announce because the export policy was deleted.
 
-**Why this happens:** SR Linux is secure by default. BGP sessions use a default-deny model for route export. Without an explicit export policy, a router receives routes from its peers (it can learn about the world) but advertises nothing back (the world cannot learn about it). The `export-connected` policy we created earlier matched `protocol local` (directly connected subnets) and accepted them for advertisement. Deleting that policy means srl3's connected routes (10.1.3.0/24 and 10.1.5.0/24) are never placed into UPDATE messages.
+**Why this happens:** SR Linux is secure by default. BGP sessions use a default-deny model for route export. Without an explicit export policy, a router receives routes from its peers (it can learn about the world) but advertises nothing back (the world cannot learn about it). The `export-connected` and `export-bgp` policies we created earlier formed a chain: `export-connected` matched directly connected subnets and advertised them, passing unmatched routes to `export-bgp` via `next-policy`; `export-bgp` then matched BGP-learned routes. Deleting both policies means srl3's connected routes (10.1.3.0/24 and 10.1.5.0/24) and any transit routes are never placed into UPDATE messages.
 
 **Why the asymmetry exists:** srl3 still receives routes from srl1 and srl2 because their export policies are intact -- they are happily advertising their subnets. So srl3 has a full routing table and host3 can reach everything. But srl1 and srl2 have no routes to 10.1.3.0/24 or 10.1.5.0/24 because srl3 is advertising nothing. From their perspective, those subnets do not exist.
 
-**Fix (re-add the export policy):**
+**Fix (re-add both export policies):**
 
 ```
 A:srl3# enter candidate
-set / network-instance default protocols bgp group ebgp-peers export-policy [export-connected]
+set / network-instance default protocols bgp group ebgp-peers export-policy [export-connected export-bgp]
 commit now
 ```
 
@@ -606,8 +626,8 @@ After deleting the static route, the BGP route (with the correct next-hop 10.1.2
 
 1. **Dynamic routing replaces manual route management with automatic route exchange** -- routers learn about remote subnets from their BGP peers instead of relying on hand-configured static routes
 2. **BGP sessions use explicit peering** -- you must configure both sides with matching AS numbers and reachable peer addresses before routes can flow
-3. **Export policies control what gets advertised** -- SR Linux default-deny means no routes are shared without a policy; a session can be Established with zero routes exchanged
-4. **BGP path selection prefers shorter AS paths** -- adding a direct link between two routers creates a shorter AS path that BGP automatically prefers, shifting traffic without manual intervention
+3. **SR Linux is default-deny for both import and export** -- you need an import policy to accept received routes and export policies to advertise them; export policies can be chained using `next-policy` for modular, composable route filtering
+4. **BGP's best path algorithm selects between competing routes** -- it evaluates Local Preference, AS Path Length, Origin, MED, eBGP/iBGP preference, and Router ID in strict order; in this lab, AS Path Length was the deciding factor because all other attributes were equal
 5. **Dynamic routing self-heals** -- link failures trigger automatic rerouting through alternate paths; the same failure that permanently broke static routing in lesson 03 was automatically recovered here
 6. **BGP session states matter** -- Established is the only healthy state; Active and Connect indicate configuration mismatches despite their misleading names
 7. **Administrative distance determines route priority** -- static routes (distance 5) beat BGP routes (170) on SR Linux; stale static routes silently override correct BGP routes, and the diagnostic clue is a received-vs-active route count mismatch


### PR DESCRIPTION
## Summary
- Add three routing policies per router: `import-all`, `export-connected` (with `next-policy`), `export-bgp` -- demonstrates policy chaining
- Add BGP best path algorithm section to README with attribute comparison table
- Update script voiceover to explain policy chaining and best path selection
- Update exercises to inspect route detail and explain which algorithm step decides
- Update solutions with corrected expected output and best path analysis

## Lesson(s) Affected
- 04-dynamic-routing-bgp

## Test plan
- [x] Clean lab redeploy + gnmic set on all 3 routers succeeds
- [x] BGP sessions established with correct Rx/Active/Tx counts
- [x] End-to-end pings work (host1->host2, host1->host3, host2->host3)
- [x] Exercise 3 break/fix CLI commands verified on running lab

🤖 Generated with [Claude Code](https://claude.com/claude-code)