### PR TITLE
fix(lesson-05): fix gnmic request-file format and leaf mgmt IPs

### DIFF
--- a/lessons/clab/05-spine-leaf-bgp/README.md
+++ b/lessons/clab/05-spine-leaf-bgp/README.md
@@ -64,12 +64,14 @@ Startup configs in `topology/configs/` handle base interface IP addressing. gNMI
 
 ```bash
 # Apply BGP configuration to all 6 routers via gNMIc
-gnmic -a clab-spine-leaf-bgp-spine1:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/spine1-bgp.json
-gnmic -a clab-spine-leaf-bgp-spine2:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/spine2-bgp.json
-gnmic -a clab-spine-leaf-bgp-leaf1:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/leaf1-bgp.json
-gnmic -a clab-spine-leaf-bgp-leaf2:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/leaf2-bgp.json
-gnmic -a clab-spine-leaf-bgp-leaf3:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/leaf3-bgp.json
-gnmic -a clab-spine-leaf-bgp-leaf4:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file gnmic/configs/leaf4-bgp.json
+# Run from the gnmic/ directory so .gnmic.yml provides credentials, encoding, and skip-verify
+cd gnmic
+gnmic -a clab-spine-leaf-bgp-spine1:57400 set --request-file configs/spine1-bgp.json
+gnmic -a clab-spine-leaf-bgp-spine2:57400 set --request-file configs/spine2-bgp.json
+gnmic -a clab-spine-leaf-bgp-leaf1:57400 set --request-file configs/leaf1-bgp.json
+gnmic -a clab-spine-leaf-bgp-leaf2:57400 set --request-file configs/leaf2-bgp.json
+gnmic -a clab-spine-leaf-bgp-leaf3:57400 set --request-file configs/leaf3-bgp.json
+gnmic -a clab-spine-leaf-bgp-leaf4:57400 set --request-file configs/leaf4-bgp.json
 ```
 
 Verify all 8 BGP sessions are Established:
@@ -229,8 +231,8 @@ In production Kubernetes clusters, the physical network underneath is almost alw
 |---------|---------|
 | `containerlab deploy -t topology/lab.clab.yml` | Deploy the lab |
 | `containerlab destroy -t topology/lab.clab.yml --cleanup` | Destroy the lab |
-| `gnmic -a HOST:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf set --update-file FILE` | Apply config via gNMIc |
-| `gnmic -a HOST:57400 -u admin -p NokiaSrl1! --skip-verify -e json_ietf get --path PATH --type state` | Read state via gNMIc |
+| `gnmic -a HOST:57400 set --request-file FILE` | Apply config via gNMIc (from `gnmic/` dir) |
+| `gnmic -a HOST:57400 get --path PATH --type state` | Read state via gNMIc (from `gnmic/` dir) |
 | `docker exec -it clab-spine-leaf-bgp-spine1 sr_cli` | Connect to spine1 CLI |
 | `show network-instance default protocols bgp neighbor` | SR Linux: BGP neighbor summary |
 | `show network-instance default protocols bgp neighbor X detail` | SR Linux: BGP neighbor detail |

--- a/lessons/clab/05-spine-leaf-bgp/exercises/README.md
+++ b/lessons/clab/05-spine-leaf-bgp/exercises/README.md
@@ -14,21 +14,15 @@ Complete these exercises to understand how CLOS spine-leaf fabrics provide scala
    containerlab deploy -t topology/lab.clab.yml
    ```
 
-2. Apply BGP config to all 6 routers using gNMIc:
+2. Apply BGP config to all 6 routers using gNMIc (run from the `gnmic/` directory so `.gnmic.yml` provides credentials):
    ```bash
    cd gnmic
-   gnmic -a clab-spine-leaf-bgp-spine1:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/spine1-bgp.json
-   gnmic -a clab-spine-leaf-bgp-spine2:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/spine2-bgp.json
-   gnmic -a clab-spine-leaf-bgp-leaf1:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/leaf1-bgp.json
-   gnmic -a clab-spine-leaf-bgp-leaf2:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/leaf2-bgp.json
-   gnmic -a clab-spine-leaf-bgp-leaf3:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/leaf3-bgp.json
-   gnmic -a clab-spine-leaf-bgp-leaf4:57400 -u admin -p NokiaSrl1! \
-     --skip-verify -e json_ietf set --update-file configs/leaf4-bgp.json
+   gnmic -a clab-spine-leaf-bgp-spine1:57400 set --request-file configs/spine1-bgp.json
+   gnmic -a clab-spine-leaf-bgp-spine2:57400 set --request-file configs/spine2-bgp.json
+   gnmic -a clab-spine-leaf-bgp-leaf1:57400 set --request-file configs/leaf1-bgp.json
+   gnmic -a clab-spine-leaf-bgp-leaf2:57400 set --request-file configs/leaf2-bgp.json
+   gnmic -a clab-spine-leaf-bgp-leaf3:57400 set --request-file configs/leaf3-bgp.json
+   gnmic -a clab-spine-leaf-bgp-leaf4:57400 set --request-file configs/leaf4-bgp.json
    ```
 
 3. Verify all 8 BGP sessions are established:

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf1-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf1-bgp.json
@@ -1,34 +1,36 @@
-[
-  {
-    "path": "/routing-policy/policy[name=export-connected]",
-    "value": {
-      "default-action": { "policy-result": "reject" },
-      "statement": [
-        {
-          "name": "10",
-          "match": { "protocol": "local" },
-          "action": { "policy-result": "accept" }
-        }
-      ]
+{
+  "updates": [
+    {
+      "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "local" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/network-instance[name=default]/protocols/bgp",
+      "value": {
+        "admin-state": "enable",
+        "autonomous-system": 65001,
+        "router-id": "10.0.2.1",
+        "group": [
+          {
+            "group-name": "spines",
+            "admin-state": "enable",
+            "export-policy": "export-connected"
+          }
+        ],
+        "neighbor": [
+          { "peer-address": "10.10.1.0", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
+          { "peer-address": "10.10.2.0", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
+        ]
+      }
     }
-  },
-  {
-    "path": "/network-instance[name=default]/protocols/bgp",
-    "value": {
-      "admin-state": "enable",
-      "autonomous-system": 65001,
-      "router-id": "10.0.2.1",
-      "group": [
-        {
-          "group-name": "spines",
-          "admin-state": "enable",
-          "export-policy": "export-connected"
-        }
-      ],
-      "neighbor": [
-        { "peer-address": "10.10.1.0", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
-        { "peer-address": "10.10.2.0", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
-      ]
-    }
-  }
-]
+  ]
+}

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf2-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf2-bgp.json
@@ -1,34 +1,36 @@
-[
-  {
-    "path": "/routing-policy/policy[name=export-connected]",
-    "value": {
-      "default-action": { "policy-result": "reject" },
-      "statement": [
-        {
-          "name": "10",
-          "match": { "protocol": "local" },
-          "action": { "policy-result": "accept" }
-        }
-      ]
+{
+  "updates": [
+    {
+      "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "local" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/network-instance[name=default]/protocols/bgp",
+      "value": {
+        "admin-state": "enable",
+        "autonomous-system": 65002,
+        "router-id": "10.0.2.2",
+        "group": [
+          {
+            "group-name": "spines",
+            "admin-state": "enable",
+            "export-policy": "export-connected"
+          }
+        ],
+        "neighbor": [
+          { "peer-address": "10.10.1.2", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
+          { "peer-address": "10.10.2.2", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
+        ]
+      }
     }
-  },
-  {
-    "path": "/network-instance[name=default]/protocols/bgp",
-    "value": {
-      "admin-state": "enable",
-      "autonomous-system": 65002,
-      "router-id": "10.0.2.2",
-      "group": [
-        {
-          "group-name": "spines",
-          "admin-state": "enable",
-          "export-policy": "export-connected"
-        }
-      ],
-      "neighbor": [
-        { "peer-address": "10.10.1.2", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
-        { "peer-address": "10.10.2.2", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
-      ]
-    }
-  }
-]
+  ]
+}

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf3-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf3-bgp.json
@@ -1,34 +1,36 @@
-[
-  {
-    "path": "/routing-policy/policy[name=export-connected]",
-    "value": {
-      "default-action": { "policy-result": "reject" },
-      "statement": [
-        {
-          "name": "10",
-          "match": { "protocol": "local" },
-          "action": { "policy-result": "accept" }
-        }
-      ]
+{
+  "updates": [
+    {
+      "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "local" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/network-instance[name=default]/protocols/bgp",
+      "value": {
+        "admin-state": "enable",
+        "autonomous-system": 65003,
+        "router-id": "10.0.2.3",
+        "group": [
+          {
+            "group-name": "spines",
+            "admin-state": "enable",
+            "export-policy": "export-connected"
+          }
+        ],
+        "neighbor": [
+          { "peer-address": "10.10.1.4", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
+          { "peer-address": "10.10.2.4", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
+        ]
+      }
     }
-  },
-  {
-    "path": "/network-instance[name=default]/protocols/bgp",
-    "value": {
-      "admin-state": "enable",
-      "autonomous-system": 65003,
-      "router-id": "10.0.2.3",
-      "group": [
-        {
-          "group-name": "spines",
-          "admin-state": "enable",
-          "export-policy": "export-connected"
-        }
-      ],
-      "neighbor": [
-        { "peer-address": "10.10.1.4", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
-        { "peer-address": "10.10.2.4", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
-      ]
-    }
-  }
-]
+  ]
+}

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf4-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf4-bgp.json
@@ -1,34 +1,36 @@
-[
-  {
-    "path": "/routing-policy/policy[name=export-connected]",
-    "value": {
-      "default-action": { "policy-result": "reject" },
-      "statement": [
-        {
-          "name": "10",
-          "match": { "protocol": "local" },
-          "action": { "policy-result": "accept" }
-        }
-      ]
+{
+  "updates": [
+    {
+      "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "local" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/network-instance[name=default]/protocols/bgp",
+      "value": {
+        "admin-state": "enable",
+        "autonomous-system": 65004,
+        "router-id": "10.0.2.4",
+        "group": [
+          {
+            "group-name": "spines",
+            "admin-state": "enable",
+            "export-policy": "export-connected"
+          }
+        ],
+        "neighbor": [
+          { "peer-address": "10.10.1.6", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
+          { "peer-address": "10.10.2.6", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
+        ]
+      }
     }
-  },
-  {
-    "path": "/network-instance[name=default]/protocols/bgp",
-    "value": {
-      "admin-state": "enable",
-      "autonomous-system": 65004,
-      "router-id": "10.0.2.4",
-      "group": [
-        {
-          "group-name": "spines",
-          "admin-state": "enable",
-          "export-policy": "export-connected"
-        }
-      ],
-      "neighbor": [
-        { "peer-address": "10.10.1.6", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
-        { "peer-address": "10.10.2.6", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
-      ]
-    }
-  }
-]
+  ]
+}

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine1-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine1-bgp.json
@@ -1,36 +1,38 @@
-[
-  {
-    "path": "/routing-policy/policy[name=export-connected]",
-    "value": {
-      "default-action": { "policy-result": "reject" },
-      "statement": [
-        {
-          "name": "10",
-          "match": { "protocol": "local" },
-          "action": { "policy-result": "accept" }
-        }
-      ]
+{
+  "updates": [
+    {
+      "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "local" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/network-instance[name=default]/protocols/bgp",
+      "value": {
+        "admin-state": "enable",
+        "autonomous-system": 65100,
+        "router-id": "10.0.1.1",
+        "group": [
+          {
+            "group-name": "leaves",
+            "admin-state": "enable",
+            "export-policy": "export-connected"
+          }
+        ],
+        "neighbor": [
+          { "peer-address": "10.10.1.1", "admin-state": "enable", "peer-as": 65001, "peer-group": "leaves" },
+          { "peer-address": "10.10.1.3", "admin-state": "enable", "peer-as": 65002, "peer-group": "leaves" },
+          { "peer-address": "10.10.1.5", "admin-state": "enable", "peer-as": 65003, "peer-group": "leaves" },
+          { "peer-address": "10.10.1.7", "admin-state": "enable", "peer-as": 65004, "peer-group": "leaves" }
+        ]
+      }
     }
-  },
-  {
-    "path": "/network-instance[name=default]/protocols/bgp",
-    "value": {
-      "admin-state": "enable",
-      "autonomous-system": 65100,
-      "router-id": "10.0.1.1",
-      "group": [
-        {
-          "group-name": "leaves",
-          "admin-state": "enable",
-          "export-policy": "export-connected"
-        }
-      ],
-      "neighbor": [
-        { "peer-address": "10.10.1.1", "admin-state": "enable", "peer-as": 65001, "peer-group": "leaves" },
-        { "peer-address": "10.10.1.3", "admin-state": "enable", "peer-as": 65002, "peer-group": "leaves" },
-        { "peer-address": "10.10.1.5", "admin-state": "enable", "peer-as": 65003, "peer-group": "leaves" },
-        { "peer-address": "10.10.1.7", "admin-state": "enable", "peer-as": 65004, "peer-group": "leaves" }
-      ]
-    }
-  }
-]
+  ]
+}

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine2-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine2-bgp.json
@@ -1,36 +1,38 @@
-[
-  {
-    "path": "/routing-policy/policy[name=export-connected]",
-    "value": {
-      "default-action": { "policy-result": "reject" },
-      "statement": [
-        {
-          "name": "10",
-          "match": { "protocol": "local" },
-          "action": { "policy-result": "accept" }
-        }
-      ]
+{
+  "updates": [
+    {
+      "path": "/routing-policy/policy[name=export-connected]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "local" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/network-instance[name=default]/protocols/bgp",
+      "value": {
+        "admin-state": "enable",
+        "autonomous-system": 65101,
+        "router-id": "10.0.1.2",
+        "group": [
+          {
+            "group-name": "leaves",
+            "admin-state": "enable",
+            "export-policy": "export-connected"
+          }
+        ],
+        "neighbor": [
+          { "peer-address": "10.10.2.1", "admin-state": "enable", "peer-as": 65001, "peer-group": "leaves" },
+          { "peer-address": "10.10.2.3", "admin-state": "enable", "peer-as": 65002, "peer-group": "leaves" },
+          { "peer-address": "10.10.2.5", "admin-state": "enable", "peer-as": 65003, "peer-group": "leaves" },
+          { "peer-address": "10.10.2.7", "admin-state": "enable", "peer-as": 65004, "peer-group": "leaves" }
+        ]
+      }
     }
-  },
-  {
-    "path": "/network-instance[name=default]/protocols/bgp",
-    "value": {
-      "admin-state": "enable",
-      "autonomous-system": 65101,
-      "router-id": "10.0.1.2",
-      "group": [
-        {
-          "group-name": "leaves",
-          "admin-state": "enable",
-          "export-policy": "export-connected"
-        }
-      ],
-      "neighbor": [
-        { "peer-address": "10.10.2.1", "admin-state": "enable", "peer-as": 65001, "peer-group": "leaves" },
-        { "peer-address": "10.10.2.3", "admin-state": "enable", "peer-as": 65002, "peer-group": "leaves" },
-        { "peer-address": "10.10.2.5", "admin-state": "enable", "peer-as": 65003, "peer-group": "leaves" },
-        { "peer-address": "10.10.2.7", "admin-state": "enable", "peer-as": 65004, "peer-group": "leaves" }
-      ]
-    }
-  }
-]
+  ]
+}

--- a/lessons/clab/05-spine-leaf-bgp/script.md
+++ b/lessons/clab/05-spine-leaf-bgp/script.md
@@ -129,18 +129,12 @@ docker exec clab-spine-leaf-bgp-host1 ping -c 2 -W 3 10.20.4.2
 
 ```bash
 cd gnmic
-gnmic -a clab-spine-leaf-bgp-spine1:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file configs/spine1-bgp.json
-gnmic -a clab-spine-leaf-bgp-spine2:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file configs/spine2-bgp.json
-gnmic -a clab-spine-leaf-bgp-leaf1:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file configs/leaf1-bgp.json
-gnmic -a clab-spine-leaf-bgp-leaf2:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file configs/leaf2-bgp.json
-gnmic -a clab-spine-leaf-bgp-leaf3:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file configs/leaf3-bgp.json
-gnmic -a clab-spine-leaf-bgp-leaf4:57400 -u admin -p NokiaSrl1! \
-  --skip-verify -e json_ietf set --update-file configs/leaf4-bgp.json
+gnmic -a clab-spine-leaf-bgp-spine1:57400 set --request-file configs/spine1-bgp.json
+gnmic -a clab-spine-leaf-bgp-spine2:57400 set --request-file configs/spine2-bgp.json
+gnmic -a clab-spine-leaf-bgp-leaf1:57400 set --request-file configs/leaf1-bgp.json
+gnmic -a clab-spine-leaf-bgp-leaf2:57400 set --request-file configs/leaf2-bgp.json
+gnmic -a clab-spine-leaf-bgp-leaf3:57400 set --request-file configs/leaf3-bgp.json
+gnmic -a clab-spine-leaf-bgp-leaf4:57400 set --request-file configs/leaf4-bgp.json
 ```
 
 > "All six applied. Let's check the sessions. I'll start with spine1 -- it should have 4 established sessions, one to each leaf."

--- a/lessons/clab/05-spine-leaf-bgp/solutions/README.md
+++ b/lessons/clab/05-spine-leaf-bgp/solutions/README.md
@@ -17,18 +17,12 @@ Expected output: table showing 10 running containers (2 spines, 4 leaves, 4 host
 
 ```bash
 $ cd gnmic
-$ gnmic -a clab-spine-leaf-bgp-spine1:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/spine1-bgp.json
-$ gnmic -a clab-spine-leaf-bgp-spine2:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/spine2-bgp.json
-$ gnmic -a clab-spine-leaf-bgp-leaf1:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/leaf1-bgp.json
-$ gnmic -a clab-spine-leaf-bgp-leaf2:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/leaf2-bgp.json
-$ gnmic -a clab-spine-leaf-bgp-leaf3:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/leaf3-bgp.json
-$ gnmic -a clab-spine-leaf-bgp-leaf4:57400 -u admin -p NokiaSrl1! \
-    --skip-verify -e json_ietf set --update-file configs/leaf4-bgp.json
+$ gnmic -a clab-spine-leaf-bgp-spine1:57400 set --request-file configs/spine1-bgp.json
+$ gnmic -a clab-spine-leaf-bgp-spine2:57400 set --request-file configs/spine2-bgp.json
+$ gnmic -a clab-spine-leaf-bgp-leaf1:57400 set --request-file configs/leaf1-bgp.json
+$ gnmic -a clab-spine-leaf-bgp-leaf2:57400 set --request-file configs/leaf2-bgp.json
+$ gnmic -a clab-spine-leaf-bgp-leaf3:57400 set --request-file configs/leaf3-bgp.json
+$ gnmic -a clab-spine-leaf-bgp-leaf4:57400 set --request-file configs/leaf4-bgp.json
 ```
 
 Each config creates the `export-connected` routing policy and enables BGP with the appropriate AS number, peer-group, and neighbors.

--- a/lessons/clab/05-spine-leaf-bgp/topology/lab.clab.yml
+++ b/lessons/clab/05-spine-leaf-bgp/topology/lab.clab.yml
@@ -26,25 +26,25 @@ topology:
     leaf1:
       kind: srl
       image: ghcr.io/nokia/srlinux:24.10.1
-      mgmt-ipv4: 172.20.20.1
+      mgmt-ipv4: 172.20.20.10
       startup-config: configs/leaf1-base.cli
 
     leaf2:
       kind: srl
       image: ghcr.io/nokia/srlinux:24.10.1
-      mgmt-ipv4: 172.20.20.2
+      mgmt-ipv4: 172.20.20.20
       startup-config: configs/leaf2-base.cli
 
     leaf3:
       kind: srl
       image: ghcr.io/nokia/srlinux:24.10.1
-      mgmt-ipv4: 172.20.20.3
+      mgmt-ipv4: 172.20.20.30
       startup-config: configs/leaf3-base.cli
 
     leaf4:
       kind: srl
       image: ghcr.io/nokia/srlinux:24.10.1
-      mgmt-ipv4: 172.20.20.4
+      mgmt-ipv4: 172.20.20.40
       startup-config: configs/leaf4-base.cli
 
     host1:


### PR DESCRIPTION
## Summary
- Convert gnmic config JSON files from bare arrays to `--request-file` format (`{"updates": [...]}`) -- `--update-file` requires a separate `--update-path` flag and can't contain embedded paths
- Update leaf management IPs to avoid `.1` addresses reserved by the container bridge (leaf1: `.10`, leaf2: `.20`, leaf3: `.30`, leaf4: `.40`)
- Simplify all gnmic commands in docs by leveraging `.gnmic.yml` for credentials, encoding, and skip-verify

## Lesson(s) Affected
- Lesson 05: Spine-Leaf Networking with BGP

## Test plan
- [ ] Topology deploys with updated mgmt IPs
- [ ] gnmic `set --request-file` applies BGP configs successfully
- [ ] All 8 BGP sessions establish
- [ ] Cross-leaf pings succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)