### PR TITLE
fix(lesson-05): fix export-policy to leaf-list per SR Linux YANG

### DIFF
--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf1-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf1-bgp.json
@@ -23,7 +23,7 @@
           {
             "group-name": "spines",
             "admin-state": "enable",
-            "export-policy": "export-connected"
+            "export-policy": ["export-connected"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf2-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf2-bgp.json
@@ -23,7 +23,7 @@
           {
             "group-name": "spines",
             "admin-state": "enable",
-            "export-policy": "export-connected"
+            "export-policy": ["export-connected"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf3-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf3-bgp.json
@@ -23,7 +23,7 @@
           {
             "group-name": "spines",
             "admin-state": "enable",
-            "export-policy": "export-connected"
+            "export-policy": ["export-connected"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf4-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf4-bgp.json
@@ -23,7 +23,7 @@
           {
             "group-name": "spines",
             "admin-state": "enable",
-            "export-policy": "export-connected"
+            "export-policy": ["export-connected"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine1-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine1-bgp.json
@@ -23,7 +23,7 @@
           {
             "group-name": "leaves",
             "admin-state": "enable",
-            "export-policy": "export-connected"
+            "export-policy": ["export-connected"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine2-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine2-bgp.json
@@ -23,7 +23,7 @@
           {
             "group-name": "leaves",
             "admin-state": "enable",
-            "export-policy": "export-connected"
+            "export-policy": ["export-connected"]
           }
         ],
         "neighbor": [


### PR DESCRIPTION
## Summary
- Change `export-policy` from string to array in all 6 gnmic BGP config files
- SR Linux YANG defines `export-policy` as a leaf-list, requiring `["export-connected"]` not `"export-connected"`

## Lesson(s) Affected
- Lesson 05: Spine-Leaf Networking with BGP

## Test plan
- [ ] gnmic `set --request-file` applies without YANG errors
- [ ] All 8 BGP sessions establish

🤖 Generated with [Claude Code](https://claude.com/claude-code)