### PR TITLE
fix(lesson-05): add BGP policies, afi-safi, and prefix-list filter

### DIFF
--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf1-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf1-bgp.json
@@ -1,13 +1,43 @@
 {
   "updates": [
     {
+      "path": "/routing-policy/prefix-set[name=host-subnets]",
+      "value": {
+        "prefix": [
+          {
+            "ip-prefix": "10.20.0.0/16",
+            "mask-length-range": "24..24"
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=import-all]",
+      "value": {
+        "default-action": { "policy-result": "accept" }
+      }
+    },
+    {
       "path": "/routing-policy/policy[name=export-connected]",
       "value": {
         "default-action": { "policy-result": "reject" },
         "statement": [
           {
             "name": "10",
-            "match": { "protocol": "local" },
+            "match": { "protocol": "local", "prefix-set": "host-subnets" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=export-bgp]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "bgp" },
             "action": { "policy-result": "accept" }
           }
         ]
@@ -19,11 +49,18 @@
         "admin-state": "enable",
         "autonomous-system": 65001,
         "router-id": "10.0.2.1",
+        "afi-safi": [
+          {
+            "afi-safi-name": "ipv4-unicast",
+            "admin-state": "enable"
+          }
+        ],
         "group": [
           {
             "group-name": "spines",
             "admin-state": "enable",
-            "export-policy": ["export-connected"]
+            "export-policy": ["export-connected", "export-bgp"],
+            "import-policy": ["import-all"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf2-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf2-bgp.json
@@ -1,13 +1,43 @@
 {
   "updates": [
     {
+      "path": "/routing-policy/prefix-set[name=host-subnets]",
+      "value": {
+        "prefix": [
+          {
+            "ip-prefix": "10.20.0.0/16",
+            "mask-length-range": "24..24"
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=import-all]",
+      "value": {
+        "default-action": { "policy-result": "accept" }
+      }
+    },
+    {
       "path": "/routing-policy/policy[name=export-connected]",
       "value": {
         "default-action": { "policy-result": "reject" },
         "statement": [
           {
             "name": "10",
-            "match": { "protocol": "local" },
+            "match": { "protocol": "local", "prefix-set": "host-subnets" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=export-bgp]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "bgp" },
             "action": { "policy-result": "accept" }
           }
         ]
@@ -19,11 +49,18 @@
         "admin-state": "enable",
         "autonomous-system": 65002,
         "router-id": "10.0.2.2",
+        "afi-safi": [
+          {
+            "afi-safi-name": "ipv4-unicast",
+            "admin-state": "enable"
+          }
+        ],
         "group": [
           {
             "group-name": "spines",
             "admin-state": "enable",
-            "export-policy": ["export-connected"]
+            "export-policy": ["export-connected", "export-bgp"],
+            "import-policy": ["import-all"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf3-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf3-bgp.json
@@ -1,13 +1,43 @@
 {
   "updates": [
     {
+      "path": "/routing-policy/prefix-set[name=host-subnets]",
+      "value": {
+        "prefix": [
+          {
+            "ip-prefix": "10.20.0.0/16",
+            "mask-length-range": "24..24"
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=import-all]",
+      "value": {
+        "default-action": { "policy-result": "accept" }
+      }
+    },
+    {
       "path": "/routing-policy/policy[name=export-connected]",
       "value": {
         "default-action": { "policy-result": "reject" },
         "statement": [
           {
             "name": "10",
-            "match": { "protocol": "local" },
+            "match": { "protocol": "local", "prefix-set": "host-subnets" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=export-bgp]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "bgp" },
             "action": { "policy-result": "accept" }
           }
         ]
@@ -19,11 +49,18 @@
         "admin-state": "enable",
         "autonomous-system": 65003,
         "router-id": "10.0.2.3",
+        "afi-safi": [
+          {
+            "afi-safi-name": "ipv4-unicast",
+            "admin-state": "enable"
+          }
+        ],
         "group": [
           {
             "group-name": "spines",
             "admin-state": "enable",
-            "export-policy": ["export-connected"]
+            "export-policy": ["export-connected", "export-bgp"],
+            "import-policy": ["import-all"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf4-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf4-bgp.json
@@ -1,13 +1,43 @@
 {
   "updates": [
     {
+      "path": "/routing-policy/prefix-set[name=host-subnets]",
+      "value": {
+        "prefix": [
+          {
+            "ip-prefix": "10.20.0.0/16",
+            "mask-length-range": "24..24"
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=import-all]",
+      "value": {
+        "default-action": { "policy-result": "accept" }
+      }
+    },
+    {
       "path": "/routing-policy/policy[name=export-connected]",
       "value": {
         "default-action": { "policy-result": "reject" },
         "statement": [
           {
             "name": "10",
-            "match": { "protocol": "local" },
+            "match": { "protocol": "local", "prefix-set": "host-subnets" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=export-bgp]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "bgp" },
             "action": { "policy-result": "accept" }
           }
         ]
@@ -19,11 +49,18 @@
         "admin-state": "enable",
         "autonomous-system": 65004,
         "router-id": "10.0.2.4",
+        "afi-safi": [
+          {
+            "afi-safi-name": "ipv4-unicast",
+            "admin-state": "enable"
+          }
+        ],
         "group": [
           {
             "group-name": "spines",
             "admin-state": "enable",
-            "export-policy": ["export-connected"]
+            "export-policy": ["export-connected", "export-bgp"],
+            "import-policy": ["import-all"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine1-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine1-bgp.json
@@ -1,13 +1,43 @@
 {
   "updates": [
     {
+      "path": "/routing-policy/prefix-set[name=host-subnets]",
+      "value": {
+        "prefix": [
+          {
+            "ip-prefix": "10.20.0.0/16",
+            "mask-length-range": "24..24"
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=import-all]",
+      "value": {
+        "default-action": { "policy-result": "accept" }
+      }
+    },
+    {
       "path": "/routing-policy/policy[name=export-connected]",
       "value": {
         "default-action": { "policy-result": "reject" },
         "statement": [
           {
             "name": "10",
-            "match": { "protocol": "local" },
+            "match": { "protocol": "local", "prefix-set": "host-subnets" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=export-bgp]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "bgp" },
             "action": { "policy-result": "accept" }
           }
         ]
@@ -19,11 +49,18 @@
         "admin-state": "enable",
         "autonomous-system": 65100,
         "router-id": "10.0.1.1",
+        "afi-safi": [
+          {
+            "afi-safi-name": "ipv4-unicast",
+            "admin-state": "enable"
+          }
+        ],
         "group": [
           {
             "group-name": "leaves",
             "admin-state": "enable",
-            "export-policy": ["export-connected"]
+            "export-policy": ["export-connected", "export-bgp"],
+            "import-policy": ["import-all"]
           }
         ],
         "neighbor": [

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine2-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine2-bgp.json
@@ -1,13 +1,43 @@
 {
   "updates": [
     {
+      "path": "/routing-policy/prefix-set[name=host-subnets]",
+      "value": {
+        "prefix": [
+          {
+            "ip-prefix": "10.20.0.0/16",
+            "mask-length-range": "24..24"
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=import-all]",
+      "value": {
+        "default-action": { "policy-result": "accept" }
+      }
+    },
+    {
       "path": "/routing-policy/policy[name=export-connected]",
       "value": {
         "default-action": { "policy-result": "reject" },
         "statement": [
           {
             "name": "10",
-            "match": { "protocol": "local" },
+            "match": { "protocol": "local", "prefix-set": "host-subnets" },
+            "action": { "policy-result": "accept" }
+          }
+        ]
+      }
+    },
+    {
+      "path": "/routing-policy/policy[name=export-bgp]",
+      "value": {
+        "default-action": { "policy-result": "reject" },
+        "statement": [
+          {
+            "name": "10",
+            "match": { "protocol": "bgp" },
             "action": { "policy-result": "accept" }
           }
         ]
@@ -19,11 +49,18 @@
         "admin-state": "enable",
         "autonomous-system": 65101,
         "router-id": "10.0.1.2",
+        "afi-safi": [
+          {
+            "afi-safi-name": "ipv4-unicast",
+            "admin-state": "enable"
+          }
+        ],
         "group": [
           {
             "group-name": "leaves",
             "admin-state": "enable",
-            "export-policy": ["export-connected"]
+            "export-policy": ["export-connected", "export-bgp"],
+            "import-policy": ["import-all"]
           }
         ],
         "neighbor": [


### PR DESCRIPTION
## Summary
- Add `ipv4-unicast` afi-safi to all configs (SR Linux precondition for enabling BGP)
- Add `import-all` policy so routes are actually accepted (SR Linux default-deny)
- Add `export-bgp` policy so spines re-advertise leaf routes to other leaves
- Add `host-subnets` prefix-set filter to `export-connected` so only /24 host subnets are advertised, not /31 fabric links
- All routers use both `export-connected` and `export-bgp` with `import-all`

## Lesson(s) Affected
- Lesson 05: Spine-Leaf Networking with BGP

## Test plan
- [x] gnmic `set --request-file` applies without errors on all 6 routers
- [x] BGP routes show host subnets only (no /31 fabric links)
- [ ] ECMP visible on leaves (two next-hops per remote host subnet)
- [ ] Cross-leaf pings succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)