### PR TITLE
fix(lesson-05): fix opening hook framing and correct Clos capitalization

### DIFF
--- a/lessons/clab/05-spine-leaf-bgp/README.md
+++ b/lessons/clab/05-spine-leaf-bgp/README.md
@@ -1,12 +1,12 @@
 # Lesson 5: Spine-Leaf Networking with BGP
 
-Deploy a CLOS spine-leaf fabric with eBGP underlay, observe ECMP across spines, and test fabric resilience.
+Deploy a Clos spine-leaf fabric with eBGP underlay, observe ECMP across spines, and test fabric resilience.
 
 ## Objectives
 
 By the end of this lesson, you will be able to:
 
-- [ ] Explain CLOS/spine-leaf architecture and why it replaced full mesh and 3-tier designs in data centers
+- [ ] Explain Clos/spine-leaf architecture and why it replaced full mesh and 3-tier designs in data centers
 - [ ] Deploy a multi-tier fabric topology with containerlab
 - [ ] Configure eBGP underlay using RFC 7938 ASN-per-device model
 - [ ] Use gNMIc to configure and verify BGP across a 6-router fabric
@@ -29,17 +29,17 @@ By the end of this lesson, you will be able to:
 
 In Lesson 4, our 3 routers were fully meshed -- every router peered with every other. That works for 3, but full mesh grows as N*(N-1)/2: 10 devices need 45 links, 50 devices need 1,225. It doesn't scale. Traditional 3-tier data center networks (core/distribution/access) solved the scaling problem but introduced Spanning Tree Protocol, which blocks redundant links to prevent loops.
 
-CLOS spine-leaf architecture eliminates these problems:
+Clos spine-leaf architecture eliminates these problems:
 
 | Approach | Bottleneck? | Redundancy | Scaling |
 |----------|-------------|------------|---------|
 | Full mesh | No, but link count explodes (N-squared) | Every device directly connected | Doesn't scale past ~10 devices |
 | 3-tier (core/dist/access) | Yes -- spanning tree blocks links | Active/standby paths | Complex, wasteful |
-| CLOS spine-leaf | No -- all paths active (ECMP) | Any spine can fail | Add spines or leaves independently |
+| Clos spine-leaf | No -- all paths active (ECMP) | Any spine can fail | Add spines or leaves independently |
 
-### 2. CLOS Topology Design (2 min)
+### 2. Clos Topology Design (2 min)
 
-In a CLOS fabric, every leaf connects to every spine. There are no leaf-to-leaf or spine-to-spine links. This creates a predictable, non-oversubscribed network where every leaf-to-leaf path crosses exactly one spine.
+In a Clos fabric, every leaf connects to every spine. There are no leaf-to-leaf or spine-to-spine links. This creates a predictable, non-oversubscribed network where every leaf-to-leaf path crosses exactly one spine.
 
 Key design principles:
 
@@ -198,7 +198,7 @@ SR Linux defaults to a single best path per prefix (`maximum-paths: 1`). To enab
 
 ## Why This Matters for Kubernetes
 
-| CLOS Concept | Kubernetes Equivalent |
+| Clos Concept | Kubernetes Equivalent |
 |---|---|
 | Spine-leaf fabric | Physical underlay for K8s nodes across racks |
 | ECMP across spines | Load balancing across multiple network paths to nodes |
@@ -207,7 +207,7 @@ SR Linux defaults to a single best path per prefix (`maximum-paths: 1`). To enab
 | Leaf as top-of-rack switch | Network boundary for a rack of K8s worker nodes |
 | Horizontal scaling (add leaves) | Adding racks of worker nodes without redesigning the network |
 
-In production Kubernetes clusters, the physical network underneath is almost always a CLOS spine-leaf fabric. Understanding how ECMP, spine failures, and BGP convergence work at this layer helps you troubleshoot connectivity issues that look like "Kubernetes problems" but are actually fabric problems.
+In production Kubernetes clusters, the physical network underneath is almost always a Clos spine-leaf fabric. Understanding how ECMP, spine failures, and BGP convergence work at this layer helps you troubleshoot connectivity issues that look like "Kubernetes problems" but are actually fabric problems.
 
 ## Files in This Lesson
 
@@ -327,4 +327,4 @@ Previous: [Lesson 4: Dynamic Routing with BGP](../04-dynamic-routing-bgp/) | [Co
 - [SR Linux BGP Configuration](https://documentation.nokia.com/srlinux/)
 - [gNMIc Documentation](https://gnmic.openconfig.net/)
 - [Containerlab Topology Reference](https://containerlab.dev/manual/topo-def-file/)
-- [CLOS Network Architecture (Wikipedia)](https://en.wikipedia.org/wiki/Clos_network)
+- [Clos Network Architecture (Wikipedia)](https://en.wikipedia.org/wiki/Clos_network)

--- a/lessons/clab/05-spine-leaf-bgp/exercises/README.md
+++ b/lessons/clab/05-spine-leaf-bgp/exercises/README.md
@@ -1,10 +1,10 @@
 # Lesson 5 Exercises: Spine-Leaf BGP Fabric
 
-Complete these exercises to understand how CLOS spine-leaf fabrics provide scalable, resilient data center connectivity using eBGP.
+Complete these exercises to understand how Clos spine-leaf fabrics provide scalable, resilient data center connectivity using eBGP.
 
 ## Exercise 1: Deploy and Configure the Fabric
 
-**Objective:** Deploy the CLOS fabric, configure eBGP on all devices, and verify end-to-end connectivity.
+**Objective:** Deploy the Clos fabric, configure eBGP on all devices, and verify end-to-end connectivity.
 
 ### Steps
 

--- a/lessons/clab/05-spine-leaf-bgp/script.md
+++ b/lessons/clab/05-spine-leaf-bgp/script.md
@@ -8,7 +8,7 @@
 | **Title** | Spine-Leaf Networking with BGP |
 | **Duration Target** | 12-14 minutes |
 | **Prerequisites** | Lessons 0-4, gNMIc installed (`gnmic version`), 16 GB RAM |
-| **Learning Objectives** | Explain CLOS architecture, configure eBGP underlay on a 6-router fabric, observe ECMP across spines, diagnose fabric resilience under spine failure |
+| **Learning Objectives** | Explain Clos architecture, configure eBGP underlay on a 6-router fabric, observe ECMP across spines, diagnose fabric resilience under spine failure |
 
 ---
 
@@ -34,7 +34,7 @@
 
 > **[VOICEOVER - Terminal visible]**
 >
-> "Last lesson, 3 routers in a triangle -- fully meshed, every router peered with every other. That works fine for 3. But what about 50 servers? Full mesh means 1,225 links and 1,225 BGP sessions. It doesn't scale. Today we build the architecture that does -- spine-leaf. This is the topology running under every major cloud provider and every large-scale Kubernetes deployment."
+> "Last lesson, you configured BGP on 3 routers and watched them exchange routes. That was the mechanics. Today we use those mechanics to build something real -- a spine-leaf fabric. In a data center, every server needs to reach every other server with predictable latency and maximum bandwidth. Spine-leaf delivers both: equal-cost paths between every pair of racks, all links active, no wasted capacity. This is the topology running under every major cloud provider and every large-scale Kubernetes deployment."
 
 **Visual:** Terminal showing lesson 04 triangle topology diagram, then transition to spine-leaf diagram
 
@@ -48,22 +48,22 @@
 >
 > Traditional data centers solved this with a 3-tier architecture: core, distribution, and access layers. But those designs relied on Spanning Tree Protocol, which blocks redundant links to prevent loops. You pay for redundant cables, then STP disables half of them. Wasteful.
 >
-> CLOS spine-leaf architecture fixes both problems. Instead of connecting everything to everything, you split the network into two tiers: spines and leaves. Every leaf connects to every spine, but there are no leaf-to-leaf or spine-to-spine links. With 4 leaves and 2 spines, that's only 8 links -- not 15 for a full mesh of 6 devices. Every path between any two leaves is exactly 2 router hops -- leaf, spine, leaf. And because all paths are equal length, the router can use ECMP -- equal-cost multipath -- to load-balance across all spines simultaneously. No blocked links. No wasted bandwidth.
+> Clos spine-leaf architecture fixes both problems. Instead of connecting everything to everything, you split the network into two tiers: spines and leaves. Every leaf connects to every spine, but there are no leaf-to-leaf or spine-to-spine links. With 4 leaves and 2 spines, that's only 8 links -- not 15 for a full mesh of 6 devices. Every path between any two leaves is exactly 2 router hops -- leaf, spine, leaf. And because all paths are equal length, the router can use ECMP -- equal-cost multipath -- to load-balance across all spines simultaneously. No blocked links. No wasted bandwidth.
 >
 > The key insight: to add more bandwidth, you add more spines. To add more servers, you add more leaves. Each tier scales independently without redesigning the other."
 
-**Visual:** Three diagrams side by side -- full mesh (link explosion highlighted), 3-tier with STP (blocked links in red), CLOS (all links green/active)
+**Visual:** Three diagrams side by side -- full mesh (link explosion highlighted), 3-tier with STP (blocked links in red), Clos (all links green/active)
 
 **Key Points:**
 - Full mesh: link count grows as N*(N-1)/2, doesn't scale
 - 3-tier + STP: blocks redundant links, wastes capacity
-- CLOS: structured 2-tier, all links active via ECMP, tiers scale independently
+- Clos: structured 2-tier, all links active via ECMP, tiers scale independently
 
 **Transition:** "Let's look at the specific design of our fabric."
 
 ---
 
-### Section 2: CLOS Design (2 minutes)
+### Section 2: Clos Design (2 minutes)
 
 > **[VOICEOVER]**
 >
@@ -237,7 +237,7 @@ exit
 >
 > "Let's recap:
 >
-> - CLOS spine-leaf replaces full mesh with a structured 2-tier design that scales. Every leaf connects to every spine, creating equal-cost paths across the fabric.
+> - Clos spine-leaf replaces full mesh with a structured 2-tier design that scales. Every leaf connects to every spine, creating equal-cost paths across the fabric.
 > - RFC 7938 gives each device a unique AS number. Every link is eBGP. But ECMP isn't automatic on SR Linux -- you need to set multipath maximum-paths to enable load balancing across spines.
 > - Prefix-set filters keep the routing table clean. Only host subnets belong in BGP -- the /31 fabric links are already known via direct connection.
 > - Spine failures degrade capacity but not connectivity. With 2 spines, you lose 50% bandwidth. With 4 spines, only 25%. The fabric degrades gracefully.
@@ -255,7 +255,7 @@ exit
 >
 > Happy labbing!"
 
-**Visual:** Show exercises folder, then CLOS diagram with "EVPN/VXLAN overlay" teaser text
+**Visual:** Show exercises folder, then Clos diagram with "EVPN/VXLAN overlay" teaser text
 
 ---
 
@@ -270,9 +270,9 @@ exit
 
 ## B-Roll / Supplementary Footage Needed
 
-1. CLOS spine-leaf topology diagram with AS numbers and IP addressing
+1. Clos spine-leaf topology diagram with AS numbers and IP addressing
 2. ECMP animation showing traffic hashing across two spines
-3. Side-by-side comparison: full mesh vs 3-tier vs CLOS
+3. Side-by-side comparison: full mesh vs 3-tier vs Clos
 4. Spine failure visualization (spine going dark, traffic rerouting through remaining spine)
 5. ECMP routing table transition: 2 next-hops -> 1 next-hop -> 2 next-hops
 
@@ -282,7 +282,7 @@ exit
 
 - **0:00-0:30** - Hook, overlay lesson 04 triangle topology diagram
 - **0:30-2:30** - Why spine-leaf, three architecture comparison diagrams
-- **2:30-4:30** - CLOS design, topology diagram with AS numbers and addressing
+- **2:30-4:30** - Clos design, topology diagram with AS numbers and addressing
 - **4:30-6:30** - Deploy fabric, show 10 containers and failed ping (no BGP yet)
 - **6:30-9:30** - Configure BGP, verify sessions, show ECMP routing table, cross-leaf pings
 - **9:30-11:30** - Spine failure demo, ping loss/recovery, ECMP path count change, restore

--- a/lessons/clab/05-spine-leaf-bgp/solutions/README.md
+++ b/lessons/clab/05-spine-leaf-bgp/solutions/README.md
@@ -121,7 +121,7 @@ PING 10.20.4.2 (10.20.4.2): 56 data bytes
 3 packets transmitted, 3 packets received, 0% packet loss
 ```
 
-Notice TTL=61. Starting TTL is 64, and the packet crosses 3 routers (leaf1 -> spine -> leaf2), so 64 - 3 = 61. This confirms the CLOS path: every cross-leaf packet traverses exactly one spine.
+Notice TTL=61. Starting TTL is 64, and the packet crosses 3 routers (leaf1 -> spine -> leaf2), so 64 - 3 = 61. This confirms the Clos path: every cross-leaf packet traverses exactly one spine.
 
 ---
 
@@ -193,11 +193,11 @@ The path is always 4 hops: host1 -> leaf1 -> spine -> leaf4 -> host4. But the sp
 
 **Step 4: Answers to the questions.**
 
-- **How many hops between any two hosts?** Always 4: host -> leaf -> spine -> leaf -> host. In a CLOS fabric, every leaf-to-leaf path is exactly 2 router hops (leaf-spine-leaf). Adding the host endpoints makes it 4 total hops. This path symmetry is a defining property of CLOS -- no host pair is closer or farther than any other.
+- **How many hops between any two hosts?** Always 4: host -> leaf -> spine -> leaf -> host. In a Clos fabric, every leaf-to-leaf path is exactly 2 router hops (leaf-spine-leaf). Adding the host endpoints makes it 4 total hops. This path symmetry is a defining property of Clos -- no host pair is closer or farther than any other.
 
-- **How many equal-cost paths exist between any two leaves?** 2 -- one through each spine. In a symmetric CLOS fabric, every leaf is exactly 2 hops from every other leaf. Traffic always traverses exactly one spine. With 2 spines, there are always 2 equal-cost paths.
+- **How many equal-cost paths exist between any two leaves?** 2 -- one through each spine. In a symmetric Clos fabric, every leaf is exactly 2 hops from every other leaf. Traffic always traverses exactly one spine. With 2 spines, there are always 2 equal-cost paths.
 
-- **What happens to bandwidth if you add a third spine?** Aggregate bandwidth between any two leaves increases by 50% (from 2 ECMP paths to 3). Each spine provides one additional path. This is the horizontal scaling property of CLOS: adding spines increases bisectional bandwidth without changing the leaf tier. No existing device needs reconfiguration beyond adding a BGP neighbor for the new spine.
+- **What happens to bandwidth if you add a third spine?** Aggregate bandwidth between any two leaves increases by 50% (from 2 ECMP paths to 3). Each spine provides one additional path. This is the horizontal scaling property of Clos: adding spines increases bisectional bandwidth without changing the leaf tier. No existing device needs reconfiguration beyond adding a BGP neighbor for the new spine.
 
 ---
 
@@ -429,10 +429,10 @@ After removing the rogue prefix-set, export policy, static route, and blackhole 
 
 ## Key Takeaways
 
-1. **CLOS spine-leaf architecture eliminates the hub bottleneck** -- every leaf connects to every spine, creating multiple equal-cost paths and removing single points of failure at the spine tier
+1. **Clos spine-leaf architecture eliminates the hub bottleneck** -- every leaf connects to every spine, creating multiple equal-cost paths and removing single points of failure at the spine tier
 2. **ECMP requires explicit multipath configuration** -- SR Linux defaults to `maximum-paths 1` (single best path). You must set `multipath maximum-paths` under the `ipv4-unicast` address family to enable load balancing across spines
 3. **Prefix-set filters keep the routing table clean** -- only host /24 subnets belong in BGP; /31 fabric links are already known via direct connection and don't need to be advertised
 4. **Fabric resilience degrades gracefully** -- losing a spine reduces aggregate bandwidth by 1/N but causes zero connectivity loss after convergence; the remaining spines absorb all traffic
 5. **RFC 7938 eBGP with ASN-per-device is the data center standard** -- each router gets a unique AS number, making every link an eBGP session with simple, uniform configuration across the fabric
-6. **Path symmetry is a CLOS property** -- every host pair is exactly 4 hops apart (host-leaf-spine-leaf-host), regardless of which leaves they connect to; this predictable latency simplifies application design
+6. **Path symmetry is a Clos property** -- every host pair is exactly 4 hops apart (host-leaf-spine-leaf-host), regardless of which leaves they connect to; this predictable latency simplifies application design
 7. **Longest-prefix-match can be weaponized** -- a more-specific prefix hijacks traffic from a less-specific one, which is why production fabrics need strict route filtering and prefix validation

--- a/lessons/clab/05-spine-leaf-bgp/topology/lab.clab.yml
+++ b/lessons/clab/05-spine-leaf-bgp/topology/lab.clab.yml
@@ -1,4 +1,4 @@
-# Lesson 5: Spine-Leaf Networking with BGP -- 2-Spine + 4-Leaf CLOS Fabric
+# Lesson 5: Spine-Leaf Networking with BGP -- 2-Spine + 4-Leaf Clos Fabric
 #
 #      spine1 (AS 65100)    spine2 (AS 65101)
 #       / |  \    \          / |   \    \


### PR DESCRIPTION
## Summary
- Rewrote opening hook to focus on what spine-leaf actually provides (predictable latency, full bandwidth utilization) instead of a strawman about full-meshing 50 routers/servers
- Corrected "CLOS" to "Clos" throughout -- named after Charles Clos, not an acronym

## Lesson(s) Affected
- Lesson 05: Spine-Leaf Networking with BGP

## Files changed
- script.md, README.md, exercises/README.md, solutions/README.md, topology/lab.clab.yml

## Test plan
- [ ] Content reviewed for accuracy
- [ ] Clos capitalization consistent across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)