### PR TITLE
feat(lesson-05): restructure for RFC 7938 compliance

### DIFF
--- a/docs/plans/2026-03-22-lesson-05-rfc7938-restructure-design.md
+++ b/docs/plans/2026-03-22-lesson-05-rfc7938-restructure-design.md
@@ -1,0 +1,157 @@
+# Lesson 05 Restructure: RFC 7938 Compliance and Script Accuracy
+
+**Date:** 2026-03-22
+**Status:** Approved
+**Scope:** Lesson 05 (Spine-Leaf BGP) -- script, README, exercises, solutions, gNMIc configs, topology comment
+
+## Problem
+
+Lesson 05 has multiple technical inaccuracies identified during review:
+
+1. **Claims to follow RFC 7938 but doesn't.** The lab assigns unique ASNs per spine (65100, 65101), but RFC 7938 Section 5.2.1 says all spines share a single ASN. Each leaf gets a unique ASN.
+2. **"Why unique ASN" paragraph inverts cause and effect.** Says unique ASNs are for "simplicity" — the actual reason is that eBGP requires different ASNs on each side by definition. RFC 7938 chose eBGP because it re-advertises freely without route reflectors.
+3. **Full-mesh strawman in Section 1.** Extrapolates lesson 04's 3-router topology to "50 routers, 1225 links" — nobody would full-mesh a data center. Lesson 04 was hub-and-spoke (full mesh only after exercise 3).
+4. **TTL/hop count contradiction.** Says "minus 3 hops" and "exactly 2 router hops" in the same narration.
+5. **export-bgp transit role unexplained.** The policy that makes spines function as transit routers is listed without explanation.
+6. **Policy chaining never introduced.** The `next-policy` default action on `export-connected` is SR Linux-specific and never explained, but referenced in the recap.
+7. **Exercise 4 fix restores wrong export-policy.** Sets `[export-connected]` instead of `[export-connected export-bgp]`.
+8. **README video outline uses `docker stop/start`** for spine failure, but script and exercises use `sr_cli` interface disable/enable.
+9. **BGP convergence timing unexplained.** Students see fast recovery but don't learn it depends on interface-level detection, not BGP timers.
+10. **Jargon without definitions.** Clos, RFC, iBGP, route reflector, router-ID, peer-group, AFI-SAFI used without explanation.
+
+## Design
+
+### ASN Model Change
+
+- Both spines: AS 65000 (shared)
+- Leaves: AS 65001-65004 (unique per device, unchanged)
+- All spine-leaf links remain eBGP (cross AS boundary)
+- Shared spine ASN means identical AS-paths through any spine, simplifying ECMP (no multipath-relax needed)
+
+### Script Structure (Approach B: Split Section 2)
+
+| # | Section | Duration | Changes |
+|---|---------|----------|---------|
+| Hook | Opening | 30s | No change (already fixed in prior PR) |
+| 1 | Why Spine-Leaf? | 2 min | Rewrite: bridge from lesson 04 hub-and-spoke->full-mesh-of-3, pivot to 3-tier/STP as the real predecessor, introduce Clos with Charles Clos attribution |
+| 2 | BGP Design Choices (NEW) | 90s | iBGP vs eBGP contrast, route reflector motivation, RFC 7938 recommendation, shared spine ASN + unique leaf ASNs, brief note on RFCs as primary source of truth |
+| 3 | Our Fabric (was 2) | 90s | Topology with updated ASNs, remove old "why unique ASN" paragraph, define peer-group and router-ID in passing |
+| 4 | Deploying the Fabric (was 3) | 2 min | Renumbered only |
+| 5 | Configure and Verify (was 4) | 3 min | Expand policy chain explanation (refresher from lesson 04), explain export-bgp transit role, prefix-set rationale moved here from recap, fix TTL narration, drop AFI-SAFI jargon |
+| 6 | Spine Failure (was 5) | 2 min | Add convergence timing note (interface-down vs hold timer, mention BFD) |
+| Recap | | 30s | Rewritten to match new framing |
+| Closing | | 30s | No change |
+
+**Target duration: 13-15 minutes**
+
+### Section 1: Why Spine-Leaf? (rewrite)
+
+- Open with lesson 04's actual progression: started hub-and-spoke, exercise 3 added the srl2-srl3 link making it a full mesh of 3
+- One sentence acknowledging full mesh gives redundancy but doesn't scale (no fake math about 50 routers)
+- Pivot to real history: 3-tier core/distribution/access with STP was the actual data center standard
+- STP blocks redundant links to prevent loops -- you pay for cables, then half are disabled
+- Clos spine-leaf: all links active via ECMP, predictable hop count, tiers scale independently
+- Define Clos on first use: "named after Charles Clos, who published this non-blocking switch design in 1953"
+
+### Section 2: BGP Design Choices (new section)
+
+Narrative arc:
+
+1. **Frame the question:** We need a routing protocol for this fabric. Lesson 4 used eBGP. Could we use iBGP instead?
+2. **iBGP's catch:** If every device shared one ASN, all sessions would be iBGP. iBGP won't re-advertise a route learned from one iBGP peer to another. Spine1 learns leaf1's subnet but won't pass it to leaf2. Fix: full iBGP mesh (doesn't scale) or route reflector (adds complexity).
+3. **RFCs as source of truth:** Brief note that RFCs (Requests for Comments) are how internet protocols are documented and standardized -- the primary source of truth for how things actually work. Encourage students to read them.
+4. **RFC 7938's answer:** Published 2016, documents how large-scale data centers (Microsoft, Facebook) solved this: eBGP for everything. Each leaf gets its own ASN. Spines share a single ASN -- they never peer with each other, so no iBGP between them. Every spine-leaf link crosses an AS boundary = eBGP.
+5. **Why this is better:** Routes re-advertised freely, no route reflectors needed. Loop prevention via AS-path. Shared spine ASN means identical AS-paths through any spine = equal-cost paths for ECMP.
+
+### Section 3: Our Fabric (updated from old Section 2)
+
+- Both spines labeled AS 65000, leaves 65001-65004
+- Remove old "Why a unique AS per device?" paragraph (covered in Section 2)
+- Define peer-group and router-ID in passing on first mention
+- Session count: 8 (4 leaves x 2 spines), unchanged
+- Note: each leaf's peer-as for both spine neighbors is 65000
+
+### Section 5: Configure and Verify (fixes)
+
+- Policy chain explanation as a refresher from lesson 04: export-connected runs first, matching host /24s via the host-subnets prefix-set. Non-matching routes fall through via `next-policy` to export-bgp, which accepts BGP-learned routes.
+- Explain export-bgp's critical transit role: "This is what makes spines work as transit routers. Without it, spine1 learns leaf1's subnet but never announces it to other leaves. SR Linux's default-deny export means nothing advertises without explicit policy."
+- Prefix-set rationale here (not deferred to recap): /31 fabric links filtered out because they're already known via direct connection.
+- TTL fix: "TTL is 61: starting at 64, decremented once by each of the 3 routers in the path -- leaf1, the spine, and leaf4. The leaf-to-leaf path is 2 fabric hops, but hosts see 3 router hops end-to-end."
+- Use "IPv4 unicast address family" instead of AFI-SAFI jargon.
+
+### Section 6: Spine Failure (addition)
+
+- After describing packet loss during convergence, add: "Recovery is fast here because disabling an interface triggers an immediate TCP teardown -- the BGP session drops instantly. In production, you'd configure BFD -- Bidirectional Forwarding Detection -- for sub-second failure detection. Without it, BGP's default hold timer is 90 seconds."
+
+### Recap (rewrite)
+
+- Clos architecture: structured 2-tier, predictable latency, all links active. Named after Charles Clos, 1953.
+- RFC 7938 eBGP: chosen because it re-advertises freely without route reflectors. Spines share ASN 65000, each leaf gets its own.
+- ECMP: shared spine ASN = identical AS-paths. SR Linux requires explicit multipath maximum-paths.
+- Policy chaining: export-connected filters host subnets, falls through to export-bgp for transit. SR Linux default-deny.
+- Fabric resilience: spine failures degrade capacity not connectivity. Fast recovery depends on interface-level detection, not BGP timers.
+- Kubernetes connection: this is the physical underlay beneath pod networking.
+
+## File Changes
+
+### gNMIc configs (`gnmic/configs/`)
+
+| File | Change |
+|------|--------|
+| `spine1-bgp.json` | `autonomous-system`: 65100 -> 65000, `router-id`: stays 10.0.1.1 |
+| `spine2-bgp.json` | `autonomous-system`: 65101 -> 65000, `router-id`: stays 10.0.1.2 |
+| `leaf1-bgp.json` | Both spine neighbor `peer-as`: 65100/65101 -> 65000 |
+| `leaf2-bgp.json` | Both spine neighbor `peer-as`: 65100/65101 -> 65000 |
+| `leaf3-bgp.json` | Both spine neighbor `peer-as`: 65100/65101 -> 65000 |
+| `leaf4-bgp.json` | Both spine neighbor `peer-as`: 65100/65101 -> 65000 |
+
+### script.md
+
+- Rewrite Section 1 (full-mesh framing)
+- Add Section 2 (BGP Design Choices) -- new content
+- Update Section 3 (was 2) with new ASNs, remove old ASN justification paragraph
+- Renumber Sections 4-6
+- Rewrite Section 5 policy explanation, fix TTL narration
+- Add convergence note to Section 6
+- Rewrite recap
+- Update duration target to 13-15 minutes
+- Update editing notes timestamps
+
+### README.md
+
+- BGP design table: both spines ASN 65000
+- Mermaid diagram: both spines AS 65000
+- Objectives list: change "RFC 7938 ASN-per-device model" to reflect shared spine ASN
+- All instances of "ASN-per-device" / "unique ASN per device" updated to describe shared-spine model
+- Video outline Section 1: updated framing
+- Video outline: add Section 2 (BGP Design Choices)
+- Video outline Section 5: `docker stop/start` -> `sr_cli` interface disable/enable
+- Section 1 text: same framing fix as script
+- Add iBGP vs eBGP context matching script Section 2
+- Jargon defined on first use (Clos, RFC, router-ID, peer-group)
+
+### exercises/README.md
+
+- Exercise 1 step 3: update config examination to reference shared spine ASN 65000
+- Exercise 4 fix step: `[export-connected]` -> `[export-connected export-bgp]`
+
+### solutions/README.md
+
+- All expected output: spine ASN shows 65000
+- BGP neighbor tables: both spine peers show AS 65000
+- Exercise 4 fix: restore `[export-connected export-bgp]`
+- Key Takeaway #5: update "ASN-per-device" language to describe shared-spine model
+
+### topology/lab.clab.yml
+
+- Comment header: update ASN references to show shared spine AS 65000
+
+### Cleanup
+
+- Delete garbage files in `gnmic/` directory (accidentally created files named with voiceover text)
+
+### Notes
+
+- `maximum-paths` values in gNMIc configs remain unchanged: 4 for spines, 2 for leaves
+- "Drop AFI-SAFI jargon" applies to voiceover/narration only; SR Linux CLI commands necessarily use `afi-safi` as the YANG path element
+- Duration target of 13-15 minutes accounts for natural rambling/expansion during recording; section estimates sum to ~12.5 minutes of scripted content

--- a/docs/plans/2026-03-22-lesson-05-rfc7938-restructure.md
+++ b/docs/plans/2026-03-22-lesson-05-rfc7938-restructure.md
@@ -1,0 +1,528 @@
+# Lesson 05 RFC 7938 Restructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure lesson 05 to properly follow RFC 7938's ASN model (shared spine ASN), fix 10 technical inaccuracies, and add a new script section on iBGP vs eBGP.
+
+**Architecture:** All spines share AS 65000. Leaves keep unique ASNs 65001-65004. Script gains a new Section 2 (BGP Design Choices) and existing sections are renumbered. All content files (script, README, exercises, solutions) and config files (gNMIc JSON) are updated to match.
+
+**Tech Stack:** Markdown (script/docs), JSON (gNMIc configs), YAML (containerlab topology)
+
+**Spec:** `docs/plans/2026-03-22-lesson-05-rfc7938-restructure-design.md`
+
+---
+
+## File Map
+
+All paths relative to `lessons/clab/05-spine-leaf-bgp/`.
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `gnmic/configs/spine1-bgp.json` | Modify | ASN 65100 -> 65000 |
+| `gnmic/configs/spine2-bgp.json` | Modify | ASN 65101 -> 65000 |
+| `gnmic/configs/leaf1-bgp.json` | Modify | peer-as 65100/65101 -> 65000 |
+| `gnmic/configs/leaf2-bgp.json` | Modify | peer-as 65100/65101 -> 65000 |
+| `gnmic/configs/leaf3-bgp.json` | Modify | peer-as 65100/65101 -> 65000 |
+| `gnmic/configs/leaf4-bgp.json` | Modify | peer-as 65100/65101 -> 65000 |
+| `topology/lab.clab.yml` | Modify | Comment header ASN update |
+| `script.md` | Rewrite | Full script restructure |
+| `README.md` | Modify | ASN refs, video outline, framing |
+| `exercises/README.md` | Modify | ASN refs, exercise 4 fix |
+| `solutions/README.md` | Modify | ASN refs in output, exercise 4 fix |
+| `gnmic/**[VOICEOVER` (garbage) | Delete | Cleanup |
+| `gnmic/10 containers are up...` (garbage) | Delete | Cleanup |
+| `gnmic/Six gNMIc commands...` (garbage) | Delete | Cleanup |
+
+---
+
+### Task 1: Update gNMIc configs -- spine ASNs
+
+**Files:**
+- Modify: `gnmic/configs/spine1-bgp.json:50`
+- Modify: `gnmic/configs/spine2-bgp.json:50`
+
+- [ ] **Step 1: Update spine1-bgp.json**
+
+Change `"autonomous-system": 65100` to `"autonomous-system": 65000` on line 50.
+
+- [ ] **Step 2: Update spine2-bgp.json**
+
+Change `"autonomous-system": 65101` to `"autonomous-system": 65000` on line 50.
+
+- [ ] **Step 3: Verify both spine configs match**
+
+Both files should now have identical ASN (65000) but different router-id values (10.0.1.1 vs 10.0.1.2) and different neighbor peer-address IPs. Everything else (policies, multipath, group name) should be identical.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gnmic/configs/spine1-bgp.json gnmic/configs/spine2-bgp.json
+git commit -m "fix(lesson-05): update spine ASNs to shared 65000 per RFC 7938"
+```
+
+---
+
+### Task 2: Update gNMIc configs -- leaf peer-as values
+
+**Files:**
+- Modify: `gnmic/configs/leaf1-bgp.json:70-71`
+- Modify: `gnmic/configs/leaf2-bgp.json:70-71`
+- Modify: `gnmic/configs/leaf3-bgp.json:70-71`
+- Modify: `gnmic/configs/leaf4-bgp.json:70-71`
+
+- [ ] **Step 1: Update leaf1-bgp.json**
+
+Line 70: change `"peer-as": 65100` to `"peer-as": 65000`
+Line 71: change `"peer-as": 65101` to `"peer-as": 65000`
+
+- [ ] **Step 2: Update leaf2-bgp.json**
+
+Same change: both spine neighbor `peer-as` values from 65100/65101 to 65000.
+
+- [ ] **Step 3: Update leaf3-bgp.json**
+
+Same change.
+
+- [ ] **Step 4: Update leaf4-bgp.json**
+
+Same change.
+
+- [ ] **Step 5: Verify all leaf configs**
+
+Each leaf config should have two neighbors, both with `"peer-as": 65000`. The leaf's own `autonomous-system` values (65001-65004) should be unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gnmic/configs/leaf*.json
+git commit -m "fix(lesson-05): update leaf peer-as to shared spine ASN 65000"
+```
+
+---
+
+### Task 3: Update topology comment and delete garbage files
+
+**Files:**
+- Modify: `topology/lab.clab.yml:1-8`
+- Delete: `gnmic/**[VOICEOVER`
+- Delete: `gnmic/10 containers are up. Let's verify that cross-leaf connectivity doesn't work yet -- without BGP, the leaves don't know about each other's host subnets.`
+- Delete: `gnmic/Six gNMIc commands, one per router. Each config file creates the export-connected policy and enables BGP with the correct AS, router-ID, peer-group, and neighbors.`
+
+- [ ] **Step 1: Update topology comment header**
+
+Replace lines 1-8 of `topology/lab.clab.yml`:
+
+```yaml
+# Lesson 5: Spine-Leaf Networking with BGP -- 2-Spine + 4-Leaf Clos Fabric
+#
+#      spine1 (AS 65000)    spine2 (AS 65000)
+#       / |  \    \          / |   \    \
+#    leaf1 leaf2 leaf3  leaf4
+#  (65001)(65002)(65003)(65004)
+#     |      |      |      |
+#   host1  host2  host3  host4
+```
+
+- [ ] **Step 2: Delete garbage files in gnmic/**
+
+```bash
+cd lessons/clab/05-spine-leaf-bgp
+rm 'gnmic/**[VOICEOVER'
+rm 'gnmic/10 containers are up. Let'\''s verify that cross-leaf connectivity doesn'\''t work yet -- without BGP, the leaves don'\''t know about each other'\''s host subnets.'
+rm 'gnmic/Six gNMIc commands, one per router. Each config file creates the export-connected policy and enables BGP with the correct AS, router-ID, peer-group, and neighbors.'
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add topology/lab.clab.yml
+git add -A gnmic/  # picks up deletions
+git commit -m "fix(lesson-05): update topology ASN comments, delete garbage files"
+```
+
+---
+
+### Task 4: Rewrite script.md
+
+This is the largest task. The changes touch most sections but some content is preserved. Apply the edits below as a single pass through the file.
+
+**Files:**
+- Modify: `script.md`
+
+**Important context for the implementer:**
+- The spec is at `docs/plans/2026-03-22-lesson-05-rfc7938-restructure-design.md` -- read it for the full narrative design of each section.
+- **All line numbers below reference the ORIGINAL file before any edits.** Since Step 3 inserts a new section, all subsequent line numbers will shift. Apply changes in document order (top to bottom) in a single pass, or read the full file first and write the complete result.
+- The opening hook (lines 33-39) was already fixed in a prior PR and must NOT be changed.
+- Pre-Recording Checklist (lines 15-28) stays unchanged.
+- Commands, SR Linux CLI snippets, and the overall demo flow (deploy, configure, verify, break, fix) stay unchanged.
+- The closing section (lines 248-258) stays unchanged.
+- "Drop AFI-SAFI jargon" applies to voiceover/narration text only. SR Linux CLI commands use `afi-safi` as the YANG path -- those must stay as-is.
+
+- [ ] **Step 1: Update lesson information table**
+
+Line 9: change `12-14 minutes` to `13-15 minutes`
+
+- [ ] **Step 2: Rewrite Section 1 (Why Spine-Leaf?)**
+
+Replace lines 43-63 with rewritten Section 1. Key changes per spec:
+- Open with lesson 04's actual progression: started hub-and-spoke, exercise 3 added srl2-srl3 making it a full mesh of 3
+- One sentence: full mesh gives redundancy but doesn't scale -- don't extrapolate to 50 routers
+- Pivot to 3-tier/STP as the real predecessor
+- Clos: all links active via ECMP, predictable hop count, tiers scale independently
+- Define Clos: "named after Charles Clos, who published this non-blocking switch design in 1953"
+- Key points updated to remove "Full mesh: link count grows as N*(N-1)/2"
+- Visual updated to reflect new framing
+
+New voiceover text:
+
+> "By the end of lesson 4, our 3 routers were fully meshed -- every router directly connected to every other. That gives you redundancy, but it only works at small scale. Real data centers with hundreds of racks never tried to full-mesh their switches.
+>
+> Instead, they used a 3-tier architecture: core, distribution, and access layers. But those designs relied on Spanning Tree Protocol, which blocks redundant links to prevent loops. You pay for redundant cables, then STP disables half of them. Wasteful.
+>
+> Clos spine-leaf architecture -- named after Charles Clos, who published this non-blocking switch design in 1953 -- solves this. You split the network into two tiers: spines and leaves. Every leaf connects to every spine, but there are no leaf-to-leaf or spine-to-spine links. Every path between any two leaves crosses exactly one spine. And because all paths are equal length, the router can use ECMP -- equal-cost multipath -- to load-balance across all spines simultaneously. No blocked links. No wasted bandwidth.
+>
+> The key insight: to add more bandwidth, add more spines. To add more servers, add more leaves. Each tier scales independently."
+
+Key points:
+- 3-tier + STP: blocks redundant links, wastes capacity
+- Clos (Charles Clos, 1953): structured 2-tier, all links active via ECMP, tiers scale independently
+- Horizontal scaling: spines add bandwidth, leaves add server ports
+
+- [ ] **Step 3: Add new Section 2 (BGP Design Choices)**
+
+Insert after Section 1 (after the `---` separator). This is entirely new content.
+
+Section heading: `### Section 2: BGP Design Choices (90 seconds)`
+
+Voiceover text:
+
+> "We need a routing protocol for this fabric. Lesson 4 used eBGP -- external BGP. Could we use iBGP -- internal BGP -- instead? If every device shared one AS number, all sessions would be iBGP. But iBGP has a catch: a router will not re-advertise a route learned from one iBGP peer to another. If leaf1 tells spine1 about its host subnet, spine1 would not pass it to leaf2. To fix this, you'd need either a full mesh of iBGP sessions between all devices, or a route reflector -- a designated router that's allowed to break that rule. Both add complexity.
+>
+> RFCs -- Requests for Comments -- are how the internet's protocols are documented and standardized. They are the primary source of truth for how things actually work. If you take one habit from this course, make it reading RFCs.
+>
+> RFC 7938, published in 2016, documents how large-scale data centers like Microsoft and Facebook solved this: use eBGP for everything. eBGP requires different AS numbers on each side of a session -- that's what makes it external. So each leaf gets its own ASN. The spines share a single ASN -- they never peer with each other, so there's no iBGP between them. Every spine-leaf link crosses an AS boundary, making it eBGP.
+>
+> The result: routes are re-advertised freely, no route reflectors needed. Loop prevention comes free through AS-path. And because all spines share one ASN, the AS-path through any spine looks identical -- which is exactly what ECMP needs to treat them as equal-cost paths."
+
+Key points:
+- iBGP won't re-advertise between peers without route reflectors
+- RFC 7938: eBGP-only underlay, unique ASN per leaf, shared ASN for all spines
+- Shared spine ASN gives identical AS-paths = natural ECMP
+
+Transition: "Let's look at the specific design of our fabric."
+
+- [ ] **Step 4: Rewrite Section 3 (Our Fabric, was Section 2)**
+
+Replace the old Section 2 (lines 66-94). New heading: `### Section 3: Our Fabric (90 seconds)`
+
+Remove the old "Why a unique AS per device?" paragraph entirely (covered in Section 2).
+
+Updated voiceover text:
+
+> "Here's our fabric: 2 spines, 4 leaves, 4 hosts. Every leaf connects to every spine -- that's 8 links. Each link gets a /31 point-to-point subnet, just like lesson 4. Each leaf also connects to one host on a /24 subnet.
+>
+> Both spines share AS 65000. Leaves are AS 65001 through 65004 -- each leaf its own autonomous system, as RFC 7938 recommends. Every spine-leaf link is an eBGP session. A peer-group is a template that applies the same BGP settings to multiple neighbors. The spines' peer-group is called 'leaves' with 4 neighbors each. The leaves' peer-group is called 'spines' with 2 neighbors each. Total: 8 BGP sessions across the fabric.
+>
+> Each router also gets a router-ID -- a unique 32-bit identifier, set to a loopback-style IP, that BGP uses to identify the router in the network."
+
+Update ASCII diagram:
+```
+     spine1 (AS 65000)    spine2 (AS 65000)
+       / |    \    \       / |    \    \
+    leaf1  leaf2  leaf3  leaf4
+  (65001) (65002) (65003) (65004)
+     |       |       |       |
+   host1   host2   host3   host4
+```
+
+Updated key points:
+- /31 point-to-point links between every spine-leaf pair
+- RFC 7938: shared spine ASN (65000), unique leaf ASNs (65001-65004), every link is eBGP
+- 8 total BGP sessions (4 leaves x 2 spines)
+- Shared spine ASN gives identical AS-paths, enabling ECMP
+
+Transition: "Let's deploy this and see it work."
+
+- [ ] **Step 5: Renumber Section 4 (Deploying the Fabric, was Section 3)**
+
+Change heading from `### Section 3: Deploying the Fabric (2 minutes)` to `### Section 4: Deploying the Fabric (2 minutes)`. No content changes.
+
+- [ ] **Step 6: Rewrite Section 5 (Configure and Verify, was Section 4)**
+
+Change heading from `### Section 4: Live Demo -- Configure and Verify (3 minutes)` to `### Section 5: Live Demo -- Configure and Verify (3 minutes)`.
+
+Replace the voiceover at line 126-128 with expanded policy explanation:
+
+> "Six gNMIc commands, one per router. Each config file creates three routing policies and chains them together -- same pattern we used in lesson 4, but worth a closer look now that 6 routers depend on it.
+>
+> The export policies are chained as a list: export-connected runs first. If a route is a connected host /24 matching the host-subnets prefix-set, accept it. If not, the next-policy default action passes it to export-bgp, which accepts BGP-learned routes. This chain is what makes spines work as transit routers -- without export-bgp, a spine would learn leaf1's host subnet but never announce it to the other leaves. SR Linux has a default-deny export policy, so nothing gets advertised unless you explicitly allow it.
+>
+> The host-subnets prefix-set filters out /31 fabric link prefixes from export-connected -- those are already known via direct connection on each router and don't need to be in BGP. Only the /24 host subnets get advertised.
+>
+> Each config also enables the IPv4 unicast address family with multipath for ECMP, and configures BGP with the correct AS, router-ID, peer-group, and neighbors."
+
+Commands stay the same (lines 130-138).
+
+Replace the TTL narration at line 171:
+
+> "All three succeed. host1 can reach host2, host3, and host4 -- all on different leaves, all going through the spine tier. Notice TTL is 61: starting at 64, decremented once by each of the 3 routers in the path -- leaf1, the spine, and leaf4. The leaf-to-leaf path is 2 fabric hops, but hosts see 3 router hops end-to-end."
+
+- [ ] **Step 7: Rewrite Section 6 (Spine Failure, was Section 5)**
+
+Change heading from `### Section 5: Live Demo -- Spine Failure (2 minutes)` to `### Section 6: Live Demo -- Spine Failure (2 minutes)`.
+
+Replace the convergence narration at line 203:
+
+> "A few packets lost during BGP convergence, then it recovers. Recovery is fast here because disabling an interface triggers an immediate TCP teardown -- the BGP session drops instantly. In a production fabric, you'd configure BFD -- Bidirectional Forwarding Detection -- for sub-second failure detection. Without it, BGP's default hold timer is 90 seconds, meaning it could take that long to notice a neighbor is gone. All traffic now flows through spine2. Let's check the routing table."
+
+All commands and remaining narration stay the same.
+
+- [ ] **Step 8: Rewrite Recap**
+
+Replace lines 234-244 with:
+
+> "Let's recap:
+>
+> - Clos spine-leaf -- named after Charles Clos's 1953 design -- is a structured 2-tier topology with predictable latency and all links active via ECMP.
+> - RFC 7938 recommends eBGP for the underlay because it re-advertises routes freely without needing route reflectors. Spines share a single ASN, each leaf gets its own. Every spine-leaf link is eBGP.
+> - ECMP works naturally because the shared spine ASN produces identical AS-paths through any spine. But SR Linux requires explicit multipath maximum-paths configuration to enable it.
+> - Export policy chaining makes it all work: export-connected advertises host subnets, export-bgp enables transit through spines. SR Linux's default-deny export means nothing advertises without explicit policy.
+> - Spine failures degrade capacity but not connectivity. Fast recovery depends on interface-level detection or BFD, not BGP's 90-second hold timer.
+> - This is the architecture under every major cloud and Kubernetes deployment. When you troubleshoot pod networking, this is what's underneath."
+
+- [ ] **Step 9: Update post-recording checklist and editing notes**
+
+Line 265: change `~12-14 minutes` to `~13-15 minutes`
+
+Replace editing notes (lines 283-290) with updated timestamps:
+
+```
+- **0:00-0:30** - Hook, overlay lesson 04 topology diagram
+- **0:30-2:30** - Why spine-leaf, STP comparison diagrams
+- **2:30-4:00** - BGP design choices: iBGP vs eBGP, RFC 7938, shared spine ASN
+- **4:00-5:30** - Our fabric: topology diagram with AS numbers and addressing
+- **5:30-7:30** - Deploy fabric, show 10 containers and failed ping (no BGP yet)
+- **7:30-10:30** - Configure BGP, policy chain explanation, verify sessions, ECMP routing table, pings
+- **10:30-12:30** - Spine failure demo, convergence timing, ping loss/recovery, restore
+- **12:30-13:00** - Recap bullet points overlay
+- **13:00-13:30** - Closing, exercises call-to-action, EVPN/VXLAN teaser
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add script.md
+git commit -m "feat(lesson-05): restructure script for RFC 7938 compliance and accuracy fixes"
+```
+
+---
+
+### Task 5: Update README.md
+
+**Files:**
+- Modify: `README.md`
+
+**Important context for the implementer:**
+- Read the current README.md first. It's ~330 lines.
+- The spec lists all required changes. Key: every instance of "ASN-per-device", "unique ASN per device", ASN 65100/65101 must be updated.
+- The README adapts the script's voiceover text for written format. When the plan says "match the new script framing," adapt the script's voiceover into concise prose: remove second-person framing ("you"), convert spoken explanations to written paragraphs with markdown formatting. Reference the completed script.md for the source content.
+
+- [ ] **Step 1: Update objectives**
+
+Line 9: change `Explain CLOS/spine-leaf architecture and why it replaced full mesh and 3-tier designs` to `Explain Clos/spine-leaf architecture and why it replaced 3-tier designs in data centers`
+
+Line 13: change `Configure eBGP underlay using RFC 7938 ASN-per-device model` to `Configure eBGP underlay using RFC 7938 (shared spine ASN, unique leaf ASNs)`
+
+- [ ] **Step 2: Rewrite Video Outline Section 1**
+
+Update the "1. Why Spine-Leaf?" section (around lines 28-38) to match the new script framing:
+- Remove full-mesh scaling math ("10 devices need 45 links, 50 devices need 1,225")
+- Bridge from lesson 04 hub-and-spoke -> full mesh of 3
+- Pivot to 3-tier/STP as the real predecessor
+- Update the comparison table: remove the "Full mesh" row or reduce it to one line, focus on 3-tier vs Clos
+- Add Clos attribution (Charles Clos, 1953)
+
+- [ ] **Step 3: Add Video Outline Section 2 (BGP Design Choices)**
+
+Insert new section after "1. Why Spine-Leaf?" covering:
+- iBGP vs eBGP contrast (brief -- 2-3 sentences)
+- RFCs as source of truth
+- RFC 7938: eBGP with shared spine ASN, unique leaf ASNs
+- Why: no route reflectors, free loop prevention, natural ECMP
+
+- [ ] **Step 4: Update Video Outline Section 2 -> 3 (Clos Topology Design)**
+
+Rename to "3. Our Fabric" and update:
+- Both spines AS 65000
+- Change "RFC 7938 eBGP with ASN-per-device" to "RFC 7938 eBGP with shared spine ASN"
+- Define peer-group and router-ID in the text
+
+- [ ] **Step 5: Update Video Outline Section 5 (Spine Failure)**
+
+Replace `docker stop/start` commands (around lines 101-114) with `sr_cli` interface disable/enable approach matching the script and exercises.
+
+- [ ] **Step 6: Update Mermaid diagram**
+
+Change both spine labels from `AS 65100`/`AS 65101` to `AS 65000`.
+
+- [ ] **Step 7: Update BGP Design table**
+
+Update the table (around lines 169-176):
+- spine1 ASN: 65100 -> 65000
+- spine2 ASN: 65101 -> 65000
+
+- [ ] **Step 8: Update Routing Policies section and BGP Multipath section**
+
+No ASN changes needed here, but verify the text doesn't reference old ASN values.
+
+- [ ] **Step 9: Update "Why This Matters for Kubernetes" table**
+
+Change "ASN-per-device (RFC 7938)" to "RFC 7938 eBGP (shared spine ASN, unique leaf ASNs)" and update the Kubernetes equivalent text.
+
+- [ ] **Step 10: Search for any remaining "65100", "65101", "ASN-per-device", or "unique ASN per device"**
+
+Run: `grep -n '65100\|65101\|ASN-per-device\|unique ASN' README.md`
+
+Fix any remaining instances.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add README.md
+git commit -m "fix(lesson-05): update README for RFC 7938 shared spine ASN model"
+```
+
+---
+
+### Task 6: Update exercises/README.md
+
+**Files:**
+- Modify: `exercises/README.md`
+
+- [ ] **Step 1: Update Exercise 1 Step 3 (config examination)**
+
+Around line 31, the config examination asks about multipath. Add a question about the shared spine ASN:
+- "Why do both spine neighbors have the same peer-as (65000)? What does RFC 7938 say about spine ASN assignment?"
+
+- [ ] **Step 2: Fix Exercise 4 export-policy restoration**
+
+Line 240: change `set / network-instance default protocols bgp group spines export-policy [export-connected]` to `set / network-instance default protocols bgp group spines export-policy [export-connected export-bgp]`
+
+- [ ] **Step 3: Search for remaining old ASN references**
+
+Run: `grep -n '65100\|65101' exercises/README.md`
+
+Fix any remaining instances.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add exercises/README.md
+git commit -m "fix(lesson-05): update exercises for shared spine ASN, fix exercise 4 export-policy"
+```
+
+---
+
+### Task 7: Update solutions/README.md
+
+**Files:**
+- Modify: `solutions/README.md`
+
+This file is ~440 lines with expected CLI output tables. Every ASN reference needs updating.
+
+- [ ] **Step 1: Update all spine ASN references in expected output**
+
+Search and replace:
+- `65100` -> `65000` in spine1 context (AS column in neighbor tables, AS-path references)
+- `65101` -> `65000` in spine2 context
+
+**Be careful:** leaf ASNs 65001-65004 must NOT be changed. Only spine ASN values.
+
+Specific locations:
+- Exercise 1 spine neighbor table (around line 60-77): spine1 shows `AS` column with leaf ASNs -- these are correct. But the `AS 65100` label for spine1 itself needs updating.
+- Exercise 1 leaf neighbor table (around line 42-52): peer AS values for spines change from 65100/65101 to 65000/65000.
+- Exercise 2 routing table: AS-path references if any.
+- Exercise 3 BGP neighbor table showing spine1 session down: peer AS values.
+- Exercise 4 fix step.
+- Key Takeaways section.
+
+- [ ] **Step 2: Fix Exercise 4 export-policy fix step**
+
+Around line 398: change `set / network-instance default protocols bgp group spines export-policy [export-connected]` to `set / network-instance default protocols bgp group spines export-policy [export-connected export-bgp]`
+
+- [ ] **Step 3: Update Key Takeaway #5**
+
+Around line 436: change "RFC 7938 eBGP with ASN-per-device is the data center standard -- each router gets a unique AS number" to "RFC 7938 eBGP is the data center standard -- spines share a single ASN, each leaf gets its own, and every spine-leaf link is eBGP"
+
+- [ ] **Step 4: Verify with grep**
+
+Run: `grep -n '65100\|65101\|ASN-per-device\|unique ASN' solutions/README.md`
+
+Should return zero matches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add solutions/README.md
+git commit -m "fix(lesson-05): update solutions for shared spine ASN, fix exercise 4 export-policy"
+```
+
+---
+
+### Task 8: Final verification and PR
+
+- [ ] **Step 1: Search all files for stale ASN references**
+
+```bash
+cd lessons/clab/05-spine-leaf-bgp
+grep -rn '65100\|65101' --include='*.md' --include='*.json' --include='*.yml'
+```
+
+Should return zero matches.
+
+- [ ] **Step 2: Search for stale "ASN-per-device" language**
+
+```bash
+grep -rn 'ASN-per-device\|unique ASN per device' --include='*.md'
+```
+
+Should return zero matches.
+
+- [ ] **Step 3: Verify garbage files are gone**
+
+```bash
+ls gnmic/ | grep -v configs | grep -v .gnmic.yml
+```
+
+Should return nothing.
+
+- [ ] **Step 4: Create PR**
+
+```bash
+git push -u origin feature/lesson-05-rfc7938-restructure
+gh pr create --base instructor --title "feat(lesson-05): restructure for RFC 7938 compliance" --body "$(cat <<'EOF'
+## Summary
+- Changed spine ASN model to follow RFC 7938: both spines share AS 65000 (was unique 65100/65101)
+- Added new script Section 2 (BGP Design Choices): iBGP vs eBGP contrast, route reflectors, RFC 7938 rationale
+- Rewrote Section 1 to bridge from lesson 04's actual topology instead of full-mesh strawman
+- Fixed TTL/hop count contradiction, explained export-bgp transit role and policy chaining
+- Added convergence timing note (fast-fallover vs hold timer, BFD)
+- Fixed exercise 4 export-policy restoration bug
+- Defined jargon on first use (Clos, RFC, iBGP, route reflector, peer-group, router-ID)
+- Deleted garbage files from gnmic/ directory
+- Updated all configs, README, exercises, and solutions to match
+
+## Lesson(s) Affected
+- Lesson 05: Spine-Leaf Networking with BGP
+
+## Test plan
+- [ ] All gNMIc configs use ASN 65000 for spines
+- [ ] No references to 65100 or 65101 remain in any file
+- [ ] No "ASN-per-device" language remains
+- [ ] Script sections renumbered correctly (1-6)
+- [ ] Exercise 4 fix restores [export-connected export-bgp]
+- [ ] Topology deploys successfully with containerlab
+- [ ] BGP sessions establish with shared spine ASN
+EOF
+)"
+```

--- a/lessons/clab/05-spine-leaf-bgp/README.md
+++ b/lessons/clab/05-spine-leaf-bgp/README.md
@@ -8,7 +8,7 @@ By the end of this lesson, you will be able to:
 
 - [ ] Explain Clos/spine-leaf architecture and why it replaced full mesh and 3-tier designs in data centers
 - [ ] Deploy a multi-tier fabric topology with containerlab
-- [ ] Configure eBGP underlay using RFC 7938 ASN-per-device model
+- [ ] Configure eBGP underlay using RFC 7938 (shared spine ASN, unique leaf ASNs)
 - [ ] Use gNMIc to configure and verify BGP across a 6-router fabric
 - [ ] Observe ECMP (equal-cost multipath) across spines
 - [ ] Diagnose fabric failures: spine loss, ECMP path changes
@@ -27,28 +27,43 @@ By the end of this lesson, you will be able to:
 
 ### 1. Why Spine-Leaf? (2 min)
 
-In Lesson 4, our 3 routers were fully meshed -- every router peered with every other. That works for 3, but full mesh grows as N*(N-1)/2: 10 devices need 45 links, 50 devices need 1,225. It doesn't scale. Traditional 3-tier data center networks (core/distribution/access) solved the scaling problem but introduced Spanning Tree Protocol, which blocks redundant links to prevent loops.
+In Lesson 4, we started with hub-and-spoke routing and then Exercise 3 pushed it to a full mesh of 3 routers -- every router peered with every other. Full mesh gives you redundancy, but it doesn't scale. As you add routers the number of links explodes, and managing a full mesh of 20 or 30 devices becomes unworkable.
 
-Clos spine-leaf architecture eliminates these problems:
+The real predecessor in data centers was the 3-tier model: core, distribution, and access layers. That solved the physical scale problem but introduced Spanning Tree Protocol to prevent loops -- and STP works by blocking redundant links. You pay for the redundancy and then deliberately disable it.
+
+Clos spine-leaf architecture, based on Charles Clos's 1953 telephone switching paper, solves both problems. Every link is active. Traffic is load-balanced across all spines via ECMP. And the tiers scale independently -- add more leaves without touching the spines, or add more spines to increase cross-fabric bandwidth.
 
 | Approach | Bottleneck? | Redundancy | Scaling |
 |----------|-------------|------------|---------|
-| Full mesh | No, but link count explodes (N-squared) | Every device directly connected | Doesn't scale past ~10 devices |
 | 3-tier (core/dist/access) | Yes -- spanning tree blocks links | Active/standby paths | Complex, wasteful |
 | Clos spine-leaf | No -- all paths active (ECMP) | Any spine can fail | Add spines or leaves independently |
 
-### 2. Clos Topology Design (2 min)
+### 2. BGP Design Choices (2 min)
+
+With the topology decided, we need a routing protocol. BGP is the standard choice for data center fabrics, but there's a design question: iBGP or eBGP?
+
+iBGP (interior BGP, same AS everywhere) has a catch -- a router won't re-advertise a route it learned via iBGP to another iBGP peer. You can work around this with route reflectors, but that adds complexity and creates scaling bottlenecks.
+
+eBGP avoids the problem entirely. When every link is an eBGP session between different autonomous systems, every router re-advertises routes naturally. No route reflectors needed.
+
+RFCs are the primary source of truth for internet protocols -- they're the formal specifications that vendors implement. RFC 7938, published in 2016, documents how large-scale data centers use BGP. Its key recommendation: eBGP-only, with a shared ASN for all spine devices and a unique ASN per leaf.
+
+Why shared spine ASN? AS-path loop prevention. If a leaf advertises a prefix up to spine1, spine1 advertises it to other leaves. Those leaves advertise it back up -- but spine2 sees the leaf's ASN already in the path and rejects it. This prevents routing loops without any additional configuration, and the shared spine ASN means leaves see equal-cost paths through both spines and ECMP kicks in automatically.
+
+### 3. Our Fabric (2 min)
 
 In a Clos fabric, every leaf connects to every spine. There are no leaf-to-leaf or spine-to-spine links. This creates a predictable, non-oversubscribed network where every leaf-to-leaf path crosses exactly one spine.
 
 Key design principles:
 
 - **/31 point-to-point links** between each spine-leaf pair (no wasted IPs)
-- **RFC 7938 eBGP with ASN-per-device** -- each router gets a unique AS number, making every link an eBGP session
+- **RFC 7938 eBGP with shared spine ASN** -- both spines share AS 65000, leaves get unique ASNs 65001-65004
+- **peer-group** configuration groups neighbors with common policy (all leaves on a spine share one peer-group, all spines on a leaf share another)
+- **router-ID** is a unique loopback-style address per device (10.0.1.x for spines, 10.0.2.x for leaves)
 - **No oversubscription between tiers** -- aggregate leaf uplink bandwidth equals spine capacity
 - **ECMP across spines** -- traffic between any two leaves is load-balanced across all available spines
 
-### 3. Deploying the Fabric (2 min)
+### 4. Deploying the Fabric (2 min)
 
 ```bash
 # Navigate to lesson directory
@@ -60,7 +75,7 @@ containerlab deploy -t topology/lab.clab.yml
 
 Startup configs in `topology/configs/` handle base interface IP addressing. gNMIc then applies BGP configuration from `gnmic/configs/`.
 
-### 4. Live Demo: Configure and Verify (3 min)
+### 5. Live Demo: Configure and Verify (3 min)
 
 ```bash
 # Apply BGP configuration to all 6 routers via gNMIc
@@ -95,11 +110,17 @@ docker exec clab-spine-leaf-bgp-host1 ping -c 3 10.20.3.2  # host1 -> host3
 docker exec clab-spine-leaf-bgp-host1 ping -c 3 10.20.4.2  # host1 -> host4
 ```
 
-### 5. Live Demo: Spine Failure and Recovery (2 min)
+### 6. Live Demo: Spine Failure and Recovery (2 min)
 
 ```bash
-# Shut down spine1 -- traffic redistributes through spine2
-docker stop clab-spine-leaf-bgp-spine1
+# Disable all spine1 interfaces toward leaves -- traffic redistributes through spine2
+docker exec -it clab-spine-leaf-bgp-spine1 sr_cli
+# enter candidate
+# set / interface ethernet-1/1 admin-state disable
+# set / interface ethernet-1/2 admin-state disable
+# set / interface ethernet-1/3 admin-state disable
+# set / interface ethernet-1/4 admin-state disable
+# commit now
 
 # Verify connectivity still works (single path through spine2)
 docker exec clab-spine-leaf-bgp-host1 ping -c 3 10.20.2.2
@@ -107,14 +128,19 @@ docker exec clab-spine-leaf-bgp-host1 ping -c 3 10.20.2.2
 # Check routing table -- only one path per destination now
 docker exec -it clab-spine-leaf-bgp-leaf1 sr_cli -c "show network-instance default route-table ipv4-unicast summary"
 
-# Bring spine1 back -- ECMP restores
-docker start clab-spine-leaf-bgp-spine1
+# Re-enable spine1 interfaces -- ECMP restores
+docker exec -it clab-spine-leaf-bgp-spine1 sr_cli
+# set / interface ethernet-1/1 admin-state enable
+# set / interface ethernet-1/2 admin-state enable
+# set / interface ethernet-1/3 admin-state enable
+# set / interface ethernet-1/4 admin-state enable
+# commit now
 
 # Verify ECMP is restored (two paths per destination)
 docker exec -it clab-spine-leaf-bgp-leaf1 sr_cli -c "show network-instance default route-table ipv4-unicast summary"
 ```
 
-### 6. Recap + Teaser (30 sec)
+### Recap + Teaser (30 sec)
 
 Pure L3 gets packets between racks. But what about VMs or containers on the same subnet across racks? EVPN/VXLAN -- coming next.
 
@@ -124,11 +150,11 @@ Pure L3 gets packets between racks. But what about VMs or containers on the same
 
 ```mermaid
 graph TB
-    spine1[spine1<br/>SR Linux<br/>AS 65100] --- leaf1[leaf1<br/>SR Linux<br/>AS 65001]
+    spine1[spine1<br/>SR Linux<br/>AS 65000] --- leaf1[leaf1<br/>SR Linux<br/>AS 65001]
     spine1 --- leaf2[leaf2<br/>SR Linux<br/>AS 65002]
     spine1 --- leaf3[leaf3<br/>SR Linux<br/>AS 65003]
     spine1 --- leaf4[leaf4<br/>SR Linux<br/>AS 65004]
-    spine2[spine2<br/>SR Linux<br/>AS 65101] --- leaf1
+    spine2[spine2<br/>SR Linux<br/>AS 65000] --- leaf1
     spine2 --- leaf2
     spine2 --- leaf3
     spine2 --- leaf4
@@ -168,8 +194,8 @@ Convention: routers get `.1`, hosts get `.2`.
 
 | Device | ASN | Router-ID | Peer Group | Neighbors |
 |--------|-----|-----------|------------|-----------|
-| spine1 | 65100 | 10.0.1.1 | leaves | leaf1 (`10.10.1.1`), leaf2 (`10.10.1.3`), leaf3 (`10.10.1.5`), leaf4 (`10.10.1.7`) |
-| spine2 | 65101 | 10.0.1.2 | leaves | leaf1 (`10.10.2.1`), leaf2 (`10.10.2.3`), leaf3 (`10.10.2.5`), leaf4 (`10.10.2.7`) |
+| spine1 | 65000 | 10.0.1.1 | leaves | leaf1 (`10.10.1.1`), leaf2 (`10.10.1.3`), leaf3 (`10.10.1.5`), leaf4 (`10.10.1.7`) |
+| spine2 | 65000 | 10.0.1.2 | leaves | leaf1 (`10.10.2.1`), leaf2 (`10.10.2.3`), leaf3 (`10.10.2.5`), leaf4 (`10.10.2.7`) |
 | leaf1 | 65001 | 10.0.2.1 | spines | spine1 (`10.10.1.0`), spine2 (`10.10.2.0`) |
 | leaf2 | 65002 | 10.0.2.2 | spines | spine1 (`10.10.1.2`), spine2 (`10.10.2.2`) |
 | leaf3 | 65003 | 10.0.2.3 | spines | spine1 (`10.10.1.4`), spine2 (`10.10.2.4`) |
@@ -203,7 +229,7 @@ SR Linux defaults to a single best path per prefix (`maximum-paths: 1`). To enab
 | Spine-leaf fabric | Physical underlay for K8s nodes across racks |
 | ECMP across spines | Load balancing across multiple network paths to nodes |
 | Spine failure / path redistribution | Node or network failure triggering pod rescheduling |
-| ASN-per-device (RFC 7938) | Calico BGP peering with unique ASN per node or rack |
+| RFC 7938 eBGP (shared spine ASN) | Calico BGP peering using shared ASN for spine tier, unique ASNs per rack |
 | Leaf as top-of-rack switch | Network boundary for a rack of K8s worker nodes |
 | Horizontal scaling (add leaves) | Adding racks of worker nodes without redesigning the network |
 

--- a/lessons/clab/05-spine-leaf-bgp/exercises/README.md
+++ b/lessons/clab/05-spine-leaf-bgp/exercises/README.md
@@ -29,6 +29,7 @@ Complete these exercises to understand how Clos spine-leaf fabrics provide scala
    - **Routing policies:** `import-all`, `export-connected`, and `export-bgp` -- why does a default-deny NOS like SR Linux need all three?
    - **Prefix-set filter:** `host-subnets` on `export-connected` -- what does `10.20.0.0/16 mask-length-range 24..24` match, and what does it exclude?
    - **Multipath:** `maximum-paths: 2` under `afi-safi ipv4-unicast` -- what is the SR Linux default, and why does ECMP require changing it?
+   - **Shared spine ASN:** Why do both spine neighbors have the same peer-as (65000)? What does RFC 7938 say about spine ASN assignment?
 
 4. Verify all 8 BGP sessions are established:
    ```bash
@@ -237,7 +238,7 @@ docker exec clab-spine-leaf-bgp-host3 ping -c 3 -W 5 10.20.4.2
    delete / routing-policy policy export-hijack
    delete / network-instance default static-routes route 10.20.4.0/25
    delete / network-instance default next-hop-groups group nhg-blackhole
-   set / network-instance default protocols bgp group spines export-policy [export-connected]
+   set / network-instance default protocols bgp group spines export-policy [export-connected export-bgp]
    commit now
    exit
    ```

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf1-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf1-bgp.json
@@ -67,8 +67,8 @@
           }
         ],
         "neighbor": [
-          { "peer-address": "10.10.1.0", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
-          { "peer-address": "10.10.2.0", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
+          { "peer-address": "10.10.1.0", "admin-state": "enable", "peer-as": 65000, "peer-group": "spines" },
+          { "peer-address": "10.10.2.0", "admin-state": "enable", "peer-as": 65000, "peer-group": "spines" }
         ]
       }
     }

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf2-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf2-bgp.json
@@ -67,8 +67,8 @@
           }
         ],
         "neighbor": [
-          { "peer-address": "10.10.1.2", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
-          { "peer-address": "10.10.2.2", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
+          { "peer-address": "10.10.1.2", "admin-state": "enable", "peer-as": 65000, "peer-group": "spines" },
+          { "peer-address": "10.10.2.2", "admin-state": "enable", "peer-as": 65000, "peer-group": "spines" }
         ]
       }
     }

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf3-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf3-bgp.json
@@ -67,8 +67,8 @@
           }
         ],
         "neighbor": [
-          { "peer-address": "10.10.1.4", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
-          { "peer-address": "10.10.2.4", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
+          { "peer-address": "10.10.1.4", "admin-state": "enable", "peer-as": 65000, "peer-group": "spines" },
+          { "peer-address": "10.10.2.4", "admin-state": "enable", "peer-as": 65000, "peer-group": "spines" }
         ]
       }
     }

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf4-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/leaf4-bgp.json
@@ -67,8 +67,8 @@
           }
         ],
         "neighbor": [
-          { "peer-address": "10.10.1.6", "admin-state": "enable", "peer-as": 65100, "peer-group": "spines" },
-          { "peer-address": "10.10.2.6", "admin-state": "enable", "peer-as": 65101, "peer-group": "spines" }
+          { "peer-address": "10.10.1.6", "admin-state": "enable", "peer-as": 65000, "peer-group": "spines" },
+          { "peer-address": "10.10.2.6", "admin-state": "enable", "peer-as": 65000, "peer-group": "spines" }
         ]
       }
     }

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine1-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine1-bgp.json
@@ -47,7 +47,7 @@
       "path": "/network-instance[name=default]/protocols/bgp",
       "value": {
         "admin-state": "enable",
-        "autonomous-system": 65100,
+        "autonomous-system": 65000,
         "router-id": "10.0.1.1",
         "afi-safi": [
           {

--- a/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine2-bgp.json
+++ b/lessons/clab/05-spine-leaf-bgp/gnmic/configs/spine2-bgp.json
@@ -47,7 +47,7 @@
       "path": "/network-instance[name=default]/protocols/bgp",
       "value": {
         "admin-state": "enable",
-        "autonomous-system": 65101,
+        "autonomous-system": 65000,
         "router-id": "10.0.1.2",
         "afi-safi": [
           {

--- a/lessons/clab/05-spine-leaf-bgp/script.md
+++ b/lessons/clab/05-spine-leaf-bgp/script.md
@@ -6,7 +6,7 @@
 |-------|-------|
 | **Lesson Number** | 05 |
 | **Title** | Spine-Leaf Networking with BGP |
-| **Duration Target** | 12-14 minutes |
+| **Duration Target** | 13-15 minutes |
 | **Prerequisites** | Lessons 0-4, gNMIc installed (`gnmic version`), 16 GB RAM |
 | **Learning Objectives** | Explain Clos architecture, configure eBGP underlay on a 6-router fabric, observe ECMP across spines, diagnose fabric resilience under spine failure |
 
@@ -44,57 +44,80 @@
 
 > **[VOICEOVER]**
 >
-> "In lesson 4, our 3 routers were fully meshed -- every router had a direct link to every other router. That's 3 links total. Add a 4th router and you need 6 links. With 10 routers, 45 links. With 50, over 1,200. Full mesh grows as N-squared -- it collapses under its own weight.
+> "By the end of lesson 4, our 3 routers were fully meshed -- every router directly connected to every other. That gives you redundancy, but it only works at small scale. Real data centers with hundreds of racks never tried to full-mesh their switches.
 >
-> Traditional data centers solved this with a 3-tier architecture: core, distribution, and access layers. But those designs relied on Spanning Tree Protocol, which blocks redundant links to prevent loops. You pay for redundant cables, then STP disables half of them. Wasteful.
+> Instead, they used a 3-tier architecture: core, distribution, and access layers. But those designs relied on Spanning Tree Protocol, which blocks redundant links to prevent loops. You pay for redundant cables, then STP disables half of them. Wasteful.
 >
-> Clos spine-leaf architecture fixes both problems. Instead of connecting everything to everything, you split the network into two tiers: spines and leaves. Every leaf connects to every spine, but there are no leaf-to-leaf or spine-to-spine links. With 4 leaves and 2 spines, that's only 8 links -- not 15 for a full mesh of 6 devices. Every path between any two leaves is exactly 2 router hops -- leaf, spine, leaf. And because all paths are equal length, the router can use ECMP -- equal-cost multipath -- to load-balance across all spines simultaneously. No blocked links. No wasted bandwidth.
+> Clos spine-leaf architecture -- named after Charles Clos, who published this non-blocking switch design in 1953 -- solves this. You split the network into two tiers: spines and leaves. Every leaf connects to every spine, but there are no leaf-to-leaf or spine-to-spine links. Every path between any two leaves crosses exactly one spine. And because all paths are equal length, the router can use ECMP -- equal-cost multipath -- to load-balance across all spines simultaneously. No blocked links. No wasted bandwidth.
 >
-> The key insight: to add more bandwidth, you add more spines. To add more servers, you add more leaves. Each tier scales independently without redesigning the other."
+> The key insight: to add more bandwidth, add more spines. To add more servers, add more leaves. Each tier scales independently."
 
-**Visual:** Three diagrams side by side -- full mesh (link explosion highlighted), 3-tier with STP (blocked links in red), Clos (all links green/active)
+**Visual:** Two diagrams side by side -- 3-tier with STP (blocked links in red), Clos (all links green/active)
 
 **Key Points:**
-- Full mesh: link count grows as N*(N-1)/2, doesn't scale
 - 3-tier + STP: blocks redundant links, wastes capacity
-- Clos: structured 2-tier, all links active via ECMP, tiers scale independently
+- Clos (Charles Clos, 1953): structured 2-tier, all links active via ECMP, tiers scale independently
+- Horizontal scaling: spines add bandwidth, leaves add server ports
+
+**Transition:** "But what routing protocol runs this fabric? Let's look at the design choices."
+
+---
+
+### Section 2: BGP Design Choices (90 seconds)
+
+> **[VOICEOVER]**
+>
+> "We need a routing protocol for this fabric. Lesson 4 used eBGP -- external BGP. Could we use iBGP -- internal BGP -- instead? If every device shared one AS number, all sessions would be iBGP. But iBGP has a catch: a router will not re-advertise a route learned from one iBGP peer to another. If leaf1 tells spine1 about its host subnet, spine1 would not pass it to leaf2. To fix this, you'd need either a full mesh of iBGP sessions between all devices, or a route reflector -- a designated router that's allowed to break that rule. Both add complexity.
+>
+> RFCs -- Requests for Comments -- are how the internet's protocols are documented and standardized. They are the primary source of truth for how things actually work. If you take one habit from this course, make it reading RFCs.
+>
+> RFC 7938, published in 2016, documents how large-scale data centers like Microsoft and Facebook solved this: use eBGP for everything. eBGP requires different AS numbers on each side of a session -- that's what makes it external. So each leaf gets its own ASN. The spines share a single ASN -- they never peer with each other, so there's no iBGP between them. Every spine-leaf link crosses an AS boundary, making it eBGP.
+>
+> The result: routes are re-advertised freely, no route reflectors needed. Loop prevention comes free through AS-path. And because all spines share one ASN, the AS-path through any spine looks identical -- which is exactly what ECMP needs to treat them as equal-cost paths."
+
+**Visual:** Diagram showing iBGP limitation (spine won't re-advertise) vs eBGP (spine freely re-advertises)
+
+**Key Points:**
+- iBGP won't re-advertise between peers without route reflectors
+- RFC 7938: eBGP-only underlay, unique ASN per leaf, shared ASN for all spines
+- Shared spine ASN gives identical AS-paths = natural ECMP
 
 **Transition:** "Let's look at the specific design of our fabric."
 
 ---
 
-### Section 2: Clos Design (2 minutes)
+### Section 3: Our Fabric (90 seconds)
 
 > **[VOICEOVER]**
 >
 > "Here's our fabric: 2 spines, 4 leaves, 4 hosts. Every leaf connects to every spine -- that's 8 links. Each link gets a /31 point-to-point subnet, just like lesson 4. Each leaf also connects to one host on a /24 subnet.
 >
-> For BGP, we use the RFC 7938 model: one unique AS number per device. Spines are AS 65100 and 65101. Leaves are AS 65001 through 65004. This means every link is an eBGP session. The spines' peer-group is called 'leaves' with 4 neighbors each. The leaves' peer-group is called 'spines' with 2 neighbors each. Total: 8 unique BGP sessions across the fabric.
+> Both spines share AS 65000. Leaves are AS 65001 through 65004 -- each leaf its own autonomous system, as RFC 7938 recommends. Every spine-leaf link is an eBGP session. A peer-group is a template that applies the same BGP settings to multiple neighbors. The spines' peer-group is called 'leaves' with 4 neighbors each. The leaves' peer-group is called 'spines' with 2 neighbors each. Total: 8 BGP sessions across the fabric.
 >
-> Why a unique AS per device? It keeps the BGP configuration simple and uniform. Every device has the same structure -- just different AS numbers and neighbor IPs. And it makes AS path the natural metric for path selection: a 2-hop path through one spine has AS path length 2, and there's no shorter alternative. All spine paths are equal cost, which is the prerequisite for ECMP -- though on SR Linux you still need to explicitly enable multipath to get load balancing."
+> Each router also gets a router-ID -- a unique 32-bit identifier, set to a loopback-style IP, that BGP uses to identify the router in the network."
 
 **Visual:** Topology diagram with AS numbers labeled, /31 subnets on links, /24 subnets on host segments
 
 ```
-     spine1 (AS 65100)    spine2 (AS 65101)
-      / |  \    \          / |   \    \
-   leaf1 leaf2 leaf3  leaf4
- (65001)(65002)(65003)(65004)
-    |      |      |      |
-  host1  host2  host3  host4
+     spine1 (AS 65000)    spine2 (AS 65000)
+       / |    \    \       / |    \    \
+    leaf1  leaf2  leaf3  leaf4
+  (65001) (65002) (65003) (65004)
+     |       |       |       |
+   host1   host2   host3   host4
 ```
 
 **Key Points:**
 - /31 point-to-point links between every spine-leaf pair
-- RFC 7938: unique ASN per device, every link is eBGP
+- RFC 7938: shared spine ASN (65000), unique leaf ASNs (65001-65004), every link is eBGP
 - 8 total BGP sessions (4 leaves x 2 spines)
-- Equal AS path length enables ECMP (with multipath configured)
+- Shared spine ASN gives identical AS-paths, enabling ECMP
 
 **Transition:** "Let's deploy this and see it work."
 
 ---
 
-### Section 3: Deploying the Fabric (2 minutes)
+### Section 4: Deploying the Fabric (2 minutes)
 
 > **[VOICEOVER]**
 >
@@ -121,11 +144,17 @@ docker exec clab-spine-leaf-bgp-host1 ping -c 2 -W 3 10.20.4.2
 
 ---
 
-### Section 4: Live Demo -- Configure and Verify (3 minutes)
+### Section 5: Live Demo -- Configure and Verify (3 minutes)
 
 > **[VOICEOVER]**
 >
-> "Six gNMIc commands, one per router. Each config file does four things: creates routing policies -- import-all, export-connected with a prefix-set filter for host subnets only, and export-bgp for re-advertising learned routes. It enables the ipv4-unicast address family with multipath for ECMP. And it configures BGP with the correct AS, router-ID, peer-group, and neighbors."
+> "Six gNMIc commands, one per router. Each config file creates three routing policies and chains them together -- same pattern we used in lesson 4, but worth a closer look now that 6 routers depend on it.
+>
+> The export policies are chained as a list: export-connected runs first. If a route is a connected host /24 matching the host-subnets prefix-set, accept it. If not, the next-policy default action passes it to export-bgp, which accepts BGP-learned routes. This chain is what makes spines work as transit routers -- without export-bgp, a spine would learn leaf1's host subnet but never announce it to the other leaves. SR Linux has a default-deny export policy, so nothing gets advertised unless you explicitly allow it.
+>
+> The host-subnets prefix-set filters out /31 fabric link prefixes from export-connected -- those are already known via direct connection on each router and don't need to be in BGP. Only the /24 host subnets get advertised.
+>
+> Each config also enables the IPv4 unicast address family with multipath for ECMP, and configures BGP with the correct AS, router-ID, peer-group, and neighbors."
 
 ```bash
 cd gnmic
@@ -168,13 +197,13 @@ docker exec clab-spine-leaf-bgp-host1 ping -c 3 10.20.3.2
 docker exec clab-spine-leaf-bgp-host1 ping -c 3 10.20.4.2
 ```
 
-> "All three succeed. host1 can reach host2, host3, and host4 -- all on different leaves, all going through the spine tier. Notice TTL is 61: starting at 64, minus 3 hops -- leaf1, spine, leaf. Every cross-leaf path is exactly 2 router hops."
+> "All three succeed. host1 can reach host2, host3, and host4 -- all on different leaves, all going through the spine tier. Notice TTL is 61: starting at 64, decremented once by each of the 3 routers in the path -- leaf1, the spine, and leaf4. The leaf-to-leaf path is 2 fabric hops, but hosts see 3 router hops end-to-end."
 
 **Visual:** Full terminal showing BGP neighbors, routing table with ECMP entries, successful pings
 
 ---
 
-### Section 5: Live Demo -- Spine Failure (2 minutes)
+### Section 6: Live Demo -- Spine Failure (2 minutes)
 
 > **[VOICEOVER]**
 >
@@ -200,7 +229,7 @@ exit
 docker exec clab-spine-leaf-bgp-host1 ping -c 20 -i 1 10.20.4.2
 ```
 
-> "A few packets lost during BGP convergence, then it recovers. All traffic now flows through spine2. Let's check the routing table."
+> "A few packets lost during BGP convergence, then it recovers. Recovery is fast here because disabling an interface triggers an immediate TCP teardown -- the BGP session drops instantly. In a production fabric, you'd configure BFD -- Bidirectional Forwarding Detection -- for sub-second failure detection. Without it, BGP's default hold timer is 90 seconds, meaning it could take that long to notice a neighbor is gone. All traffic now flows through spine2. Let's check the routing table."
 
 ```bash
 docker exec -it clab-spine-leaf-bgp-leaf1 sr_cli -c \
@@ -237,10 +266,11 @@ exit
 >
 > "Let's recap:
 >
-> - Clos spine-leaf replaces full mesh with a structured 2-tier design that scales. Every leaf connects to every spine, creating equal-cost paths across the fabric.
-> - RFC 7938 gives each device a unique AS number. Every link is eBGP. But ECMP isn't automatic on SR Linux -- you need to set multipath maximum-paths to enable load balancing across spines.
-> - Prefix-set filters keep the routing table clean. Only host subnets belong in BGP -- the /31 fabric links are already known via direct connection.
-> - Spine failures degrade capacity but not connectivity. With 2 spines, you lose 50% bandwidth. With 4 spines, only 25%. The fabric degrades gracefully.
+> - Clos spine-leaf -- named after Charles Clos's 1953 design -- is a structured 2-tier topology with predictable latency and all links active via ECMP.
+> - RFC 7938 recommends eBGP for the underlay because it re-advertises routes freely without needing route reflectors. Spines share a single ASN, each leaf gets its own. Every spine-leaf link is eBGP.
+> - ECMP works naturally because the shared spine ASN produces identical AS-paths through any spine. But SR Linux requires explicit multipath maximum-paths configuration to enable it.
+> - Export policy chaining makes it all work: export-connected advertises host subnets, export-bgp enables transit through spines. SR Linux's default-deny export means nothing advertises without explicit policy.
+> - Spine failures degrade capacity but not connectivity. Fast recovery depends on interface-level detection or BFD, not BGP's 90-second hold timer.
 > - This is the architecture under every major cloud and Kubernetes deployment. When you troubleshoot pod networking, this is what's underneath."
 
 ---
@@ -262,7 +292,7 @@ exit
 ## Post-Recording Checklist
 
 - [ ] Lab destroyed: `containerlab destroy --all`
-- [ ] Timing verified: ~12-14 minutes
+- [ ] Timing verified: ~13-15 minutes
 - [ ] All commands worked correctly
 - [ ] Transcript updated with actual output
 
@@ -280,11 +310,12 @@ exit
 
 ## Notes for Editing
 
-- **0:00-0:30** - Hook, overlay lesson 04 triangle topology diagram
-- **0:30-2:30** - Why spine-leaf, three architecture comparison diagrams
-- **2:30-4:30** - Clos design, topology diagram with AS numbers and addressing
-- **4:30-6:30** - Deploy fabric, show 10 containers and failed ping (no BGP yet)
-- **6:30-9:30** - Configure BGP, verify sessions, show ECMP routing table, cross-leaf pings
-- **9:30-11:30** - Spine failure demo, ping loss/recovery, ECMP path count change, restore
-- **11:30-12:00** - Recap bullet points overlay
-- **12:00-12:30** - Closing, exercises call-to-action, EVPN/VXLAN teaser
+- **0:00-0:30** - Hook, overlay lesson 04 topology diagram
+- **0:30-2:30** - Why spine-leaf, STP comparison diagrams
+- **2:30-4:00** - BGP design choices: iBGP vs eBGP, RFC 7938, shared spine ASN
+- **4:00-5:30** - Our fabric: topology diagram with AS numbers and addressing
+- **5:30-7:30** - Deploy fabric, show 10 containers and failed ping (no BGP yet)
+- **7:30-10:30** - Configure BGP, policy chain explanation, verify sessions, ECMP routing table, pings
+- **10:30-12:30** - Spine failure demo, convergence timing, ping loss/recovery, restore
+- **12:30-13:00** - Recap bullet points overlay
+- **13:00-13:30** - Closing, exercises call-to-action, EVPN/VXLAN teaser

--- a/lessons/clab/05-spine-leaf-bgp/solutions/README.md
+++ b/lessons/clab/05-spine-leaf-bgp/solutions/README.md
@@ -43,10 +43,10 @@ A:leaf1# show network-instance default protocols bgp neighbor
 | Peer          | Group  | AS     | Admin     | Session| Rcv    | Active |
 |               |        |        | State     | State  | Routes | Routes |
 +===============+========+========+===========+========+========+========+
-| 10.10.1.0     |spines  | 65100  | enable    |establis| 3      | 3      |
+| 10.10.1.0     |spines  | 65000  | enable    |establis| 3      | 3      |
 |               |        |        |           | hed    |        |        |
 +---------------+--------+--------+-----------+--------+--------+--------+
-| 10.10.2.0     |spines  | 65101  | enable    |establis| 3      | 3      |
+| 10.10.2.0     |spines  | 65000  | enable    |establis| 3      | 3      |
 |               |        |        |           | hed    |        |        |
 +---------------+--------+--------+-----------+--------+--------+--------+
 ```
@@ -284,10 +284,10 @@ A:leaf1# show network-instance default protocols bgp neighbor
 | Peer          | Group  | AS     | Admin     | Session| Rcv    | Active |
 |               |        |        | State     | State  | Routes | Routes |
 +===============+========+========+===========+========+========+========+
-| 10.10.1.0     |spines  | 65100  | enable    |active  | 0      | 0      |
+| 10.10.1.0     |spines  | 65000  | enable    |active  | 0      | 0      |
 |               |        |        |           |        |        |        |
 +---------------+--------+--------+-----------+--------+--------+--------+
-| 10.10.2.0     |spines  | 65101  | enable    |establis| 6      | 3      |
+| 10.10.2.0     |spines  | 65000  | enable    |establis| 6      | 3      |
 |               |        |        |           | hed    |        |        |
 +---------------+--------+--------+-----------+--------+--------+--------+
 ```
@@ -395,7 +395,7 @@ delete / routing-policy prefix-set hijack
 delete / routing-policy policy export-hijack
 delete / network-instance default static-routes route 10.20.4.0/25
 delete / network-instance default next-hop-groups group nhg-blackhole
-set / network-instance default protocols bgp group spines export-policy [export-connected]
+set / network-instance default protocols bgp group spines export-policy [export-connected export-bgp]
 commit now
 ```
 
@@ -433,6 +433,6 @@ After removing the rogue prefix-set, export policy, static route, and blackhole 
 2. **ECMP requires explicit multipath configuration** -- SR Linux defaults to `maximum-paths 1` (single best path). You must set `multipath maximum-paths` under the `ipv4-unicast` address family to enable load balancing across spines
 3. **Prefix-set filters keep the routing table clean** -- only host /24 subnets belong in BGP; /31 fabric links are already known via direct connection and don't need to be advertised
 4. **Fabric resilience degrades gracefully** -- losing a spine reduces aggregate bandwidth by 1/N but causes zero connectivity loss after convergence; the remaining spines absorb all traffic
-5. **RFC 7938 eBGP with ASN-per-device is the data center standard** -- each router gets a unique AS number, making every link an eBGP session with simple, uniform configuration across the fabric
+5. **RFC 7938 eBGP is the data center standard** -- spines share a single ASN, each leaf gets its own, and every spine-leaf link is eBGP
 6. **Path symmetry is a Clos property** -- every host pair is exactly 4 hops apart (host-leaf-spine-leaf-host), regardless of which leaves they connect to; this predictable latency simplifies application design
 7. **Longest-prefix-match can be weaponized** -- a more-specific prefix hijacks traffic from a less-specific one, which is why production fabrics need strict route filtering and prefix validation

--- a/lessons/clab/05-spine-leaf-bgp/topology/lab.clab.yml
+++ b/lessons/clab/05-spine-leaf-bgp/topology/lab.clab.yml
@@ -1,6 +1,6 @@
 # Lesson 5: Spine-Leaf Networking with BGP -- 2-Spine + 4-Leaf Clos Fabric
 #
-#      spine1 (AS 65100)    spine2 (AS 65101)
+#      spine1 (AS 65000)    spine2 (AS 65000)
 #       / |  \    \          / |   \    \
 #    leaf1 leaf2 leaf3  leaf4
 #  (65001)(65002)(65003)(65004)


### PR DESCRIPTION
## Summary
- Changed spine ASN model to follow RFC 7938: both spines share AS 65000 (was unique 65100/65101)
- Added new script Section 2 (BGP Design Choices): iBGP vs eBGP contrast, route reflectors, RFC 7938 rationale, RFCs as source of truth
- Rewrote Section 1 to bridge from lesson 04's actual topology (hub-and-spoke -> full mesh of 3) instead of full-mesh strawman
- Fixed TTL/hop count contradiction (3 router hops vs 2 fabric hops distinction)
- Explained export-bgp transit role and policy chaining (refresher from lesson 04)
- Added convergence timing note (fast-fallover vs 90s hold timer, BFD introduction)
- Fixed exercise 4 export-policy restoration bug (`[export-connected]` -> `[export-connected export-bgp]`)
- Defined jargon on first use (Clos/Charles Clos 1953, RFC, iBGP, route reflector, peer-group, router-ID)
- Fixed README spine failure to use sr_cli (was docker stop/start)
- Deleted garbage files from gnmic/ directory
- Updated all gNMIc configs, README, exercises, and solutions to match

## Lesson(s) Affected
- Lesson 05: Spine-Leaf Networking with BGP

## Test plan
- [x] All gNMIc configs use ASN 65000 for spines
- [x] No references to 65100 or 65101 remain in any file
- [x] No "ASN-per-device" language remains
- [x] Script sections renumbered correctly (1-6)
- [x] Exercise 4 fix restores [export-connected export-bgp]
- [ ] Topology deploys successfully with containerlab
- [ ] BGP sessions establish with shared spine ASN

🤖 Generated with [Claude Code](https://claude.com/claude-code)