### PR TITLE
fix(lesson-05): correct exercise 4 "break it" config inside leaf1

### DIFF
--- a/lessons/clab/05-spine-leaf-bgp/exercises/README.md
+++ b/lessons/clab/05-spine-leaf-bgp/exercises/README.md
@@ -190,13 +190,12 @@ enter candidate
 set / routing-policy prefix-set hijack prefix 10.20.4.0/25 mask-length-range exact
 set / routing-policy policy export-hijack statement 10 match prefix-set hijack
 set / routing-policy policy export-hijack statement 10 action policy-result accept
-set / routing-policy policy export-hijack statement 20 match protocol local
-set / routing-policy policy export-hijack statement 20 action policy-result accept
+set / routing-policy policy export-hijack statement 10 match protocol static
 set / routing-policy policy export-hijack default-action policy-result reject
 set / network-instance default protocols bgp group spines export-policy [export-hijack]
 set / network-instance default static-routes route 10.20.4.0/25 admin-state enable
 set / network-instance default next-hop-groups group nhg-blackhole admin-state enable
-set / network-instance default next-hop-groups group nhg-blackhole nexthop 1 ip-address 192.0.2.1
+set / network-instance default next-hop-groups group nhg-blackhole blackhole
 set / network-instance default static-routes route 10.20.4.0/25 next-hop-group nhg-blackhole
 commit now
 exit


### PR DESCRIPTION
Two bugs prevented the route leak/hijack scenario from working:

1. `protocol local` matched connected routes instead of the static blackhole route. Replaced with `protocol static` on statement 10
2. `ip-address 192.0.2.1` as the blackhole nexthop is unreachable so SR Linux never installs the /25 into the RIB. Replaced with the native `blackhole` NHG syntax

Without both fixes the /25 is never installed or advertised, leaf2/leaf3 never receive it, and pings to host4 succeed throughout, which is the opposite of the intended symptom.